### PR TITLE
Remote nail attacks use generic attack type

### DIFF
--- a/HKMP/Animation/AnimationEffect.cs
+++ b/HKMP/Animation/AnimationEffect.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using HutongGames.PlayMaker.Actions;
+using ModCommon.Util;
+using UnityEngine;
 
 namespace HKMP.Animation {
     public abstract class AnimationEffect : IAnimationEffect {
@@ -10,6 +12,24 @@ namespace HKMP.Animation {
 
         public void SetGameSettings(Game.Settings.GameSettings gameSettings) {
             GameSettings = gameSettings;
+        }
+
+        /**
+         * Locate the damages_enemy FSM and change the attack type to generic.
+         * This will avoid the local player taking knockback from remote players hitting shields etc.
+         */
+        protected static void ChangeAttackTypeOfFsm(GameObject targetObject) {
+            var damageFsm = targetObject.LocateMyFSM("damages_enemy");
+            if (damageFsm == null) {
+                return;
+            }
+            
+            var takeDamage = damageFsm.GetAction<TakeDamage>("Send Event", 8);
+            takeDamage.AttackType.Value = (int) AttackTypes.Generic;
+            takeDamage = damageFsm.GetAction<TakeDamage>("Parent", 6);
+            takeDamage.AttackType.Value = (int) AttackTypes.Generic;
+            takeDamage = damageFsm.GetAction<TakeDamage>("Grandparent", 6);
+            takeDamage.AttackType.Value = (int) AttackTypes.Generic;
         }
     }
 }

--- a/HKMP/Animation/Effects/AltSlash.cs
+++ b/HKMP/Animation/Effects/AltSlash.cs
@@ -8,7 +8,7 @@ namespace HKMP.Animation.Effects {
     public class AltSlash : SlashBase {
         public override void Play(GameObject playerObject, bool[] effectInfo) {
             // Call the base function with the correct parameters
-            Play(playerObject, effectInfo, HeroController.instance.slashAltPrefab, false, false, false);
+            Play(playerObject, effectInfo, HeroController.instance.slashAltPrefab, SlashType.Alt);
         }
     }
 }

--- a/HKMP/Animation/Effects/CycloneSlash.cs
+++ b/HKMP/Animation/Effects/CycloneSlash.cs
@@ -29,8 +29,15 @@ namespace HKMP.Animation.Effects {
                 cycloneObj, 
                 playerAttacks.transform
             );
-            cycloneSlash.SetActive(true);
             cycloneSlash.layer = 22;
+
+            var hitLComponent = cycloneSlash.FindGameObjectInChildren("Hit L");
+            ChangeAttackTypeOfFsm(hitLComponent);
+
+            var hitRComponent = cycloneSlash.FindGameObjectInChildren("Hit R");
+            ChangeAttackTypeOfFsm(hitRComponent);
+
+            cycloneSlash.SetActive(true);
 
             // Set a name, so we can reference it later when we need to destroy it
             cycloneSlash.name = "Cyclone Slash";
@@ -41,26 +48,8 @@ namespace HKMP.Animation.Effects {
 
             var damage = GameSettings.CycloneSlashDamage;
             if (GameSettings.IsPvpEnabled && ShouldDoDamage && damage != 0) {
-                var hitSides = new[] {
-                    cycloneSlash.FindGameObjectInChildren("Hit L"),
-                    cycloneSlash.FindGameObjectInChildren("Hit R")
-                };
-
-                foreach (var hitSide in hitSides) {
-                    // We instantiate the Hive Knight Slash for the parry effect
-                    var cycloneHitCollider = Object.Instantiate(
-                        HKMP.PreloadedObjects["HiveKnightSlash"],
-                        hitSide.transform
-                    );
-                    cycloneHitCollider.SetActive(true);
-                    cycloneHitCollider.layer = 22;
-
-                    // Get the polygon collider of the original and copy over the points
-                    cycloneHitCollider.GetComponent<PolygonCollider2D>().points =
-                        hitSide.GetComponent<PolygonCollider2D>().points;
-
-                    cycloneHitCollider.GetComponent<DamageHero>().damageDealt = damage;
-                }
+                hitLComponent.AddComponent<DamageHero>().damageDealt = damage;
+                hitRComponent.AddComponent<DamageHero>().damageDealt = damage;
             }
 
             // As a failsafe, destroy the cyclone slash after 4 seconds

--- a/HKMP/Animation/Effects/DashSlash.cs
+++ b/HKMP/Animation/Effects/DashSlash.cs
@@ -30,8 +30,11 @@ namespace HKMP.Animation.Effects {
                 dashSlashObject,
                 playerAttacks.transform
             );
-            dashSlash.SetActive(true);
             dashSlash.layer = 22;
+            
+            ChangeAttackTypeOfFsm(dashSlash);
+            
+            dashSlash.SetActive(true);
 
             // Remove audio source component that exists on the dash slash object
             Object.Destroy(dashSlash.GetComponent<AudioSource>());
@@ -42,9 +45,14 @@ namespace HKMP.Animation.Effects {
 
             var damage = GameSettings.DashSlashDamage;
             if (GameSettings.IsPvpEnabled && ShouldDoDamage && damage != 0) {
-                // Instantiate the Hive Knight Slash 
+                // Somehow adding a DamageHero component simply to the dash slash object doesn't work,
+                // so we create a separate object for it
                 var dashSlashCollider = Object.Instantiate(
-                    HKMP.PreloadedObjects["HiveKnightSlash"],
+                    new GameObject(
+                        "DashSlashCollider",
+                        typeof(PolygonCollider2D),
+                        typeof(DamageHero)
+                    ), 
                     dashSlash.transform
                 );
                 dashSlashCollider.SetActive(true);
@@ -56,7 +64,7 @@ namespace HKMP.Animation.Effects {
 
                 dashSlashCollider.GetComponent<DamageHero>().damageDealt = damage;
             }
-            
+
             // Get the animator, figure out the duration of the animation and destroy the object accordingly afterwards
             var dashSlashAnimator = dashSlash.GetComponent<tk2dSpriteAnimator>();
             var dashSlashAnimationDuration = dashSlashAnimator.DefaultClip.frames.Length / dashSlashAnimator.ClipFps;

--- a/HKMP/Animation/Effects/DownSlash.cs
+++ b/HKMP/Animation/Effects/DownSlash.cs
@@ -7,7 +7,7 @@ namespace HKMP.Animation.Effects {
     public class DownSlash : SlashBase {
         public override void Play(GameObject playerObject, bool[] effectInfo) {
             // Call the base function with the correct parameters
-            Play(playerObject, effectInfo, HeroController.instance.downSlashPrefab, true, false, false);
+            Play(playerObject, effectInfo, HeroController.instance.downSlashPrefab, SlashType.Down);
         }
     }
 }

--- a/HKMP/Animation/Effects/GreatSlash.cs
+++ b/HKMP/Animation/Effects/GreatSlash.cs
@@ -30,8 +30,11 @@ namespace HKMP.Animation.Effects {
                 greatSlashObject,
                 playerAttacks.transform
             );
-            greatSlash.SetActive(true);
             greatSlash.layer = 22;
+
+            ChangeAttackTypeOfFsm(greatSlash);
+            
+            greatSlash.SetActive(true);
 
             // Set the newly instantiate collider to state Init, to reset it
             // in case the local player was already performing it
@@ -39,19 +42,7 @@ namespace HKMP.Animation.Effects {
 
             var damage = GameSettings.GreatSlashDamage;
             if (GameSettings.IsPvpEnabled && ShouldDoDamage && damage != 0) {
-                // Instantiate the Hive Knight Slash 
-                var greatSlashCollider = Object.Instantiate(
-                    HKMP.PreloadedObjects["HiveKnightSlash"],
-                    greatSlash.transform
-                );
-                greatSlashCollider.SetActive(true);
-                greatSlashCollider.layer = 22;
-
-                // Copy over the polygon collider points
-                greatSlashCollider.GetComponent<PolygonCollider2D>().points =
-                    greatSlash.GetComponent<PolygonCollider2D>().points;
-                
-                greatSlashCollider.GetComponent<DamageHero>().damageDealt = damage;
+                greatSlash.AddComponent<DamageHero>().damageDealt = damage;
             }
             
             // Get the animator, figure out the duration of the animation and destroy the object accordingly afterwards

--- a/HKMP/Animation/Effects/Slash.cs
+++ b/HKMP/Animation/Effects/Slash.cs
@@ -7,7 +7,7 @@ namespace HKMP.Animation.Effects {
     public class Slash : SlashBase {
         public override void Play(GameObject playerObject, bool[] effectInfo) {
             // Call the base function with the correct parameters
-            Play(playerObject, effectInfo, HeroController.instance.slashPrefab, false, false, false);
+            Play(playerObject, effectInfo, HeroController.instance.slashPrefab, SlashType.Normal);
         }
     }
 }

--- a/HKMP/Animation/Effects/SlashBase.cs
+++ b/HKMP/Animation/Effects/SlashBase.cs
@@ -40,15 +40,7 @@ namespace HKMP.Animation.Effects {
             var originalNailSlash = slash.GetComponent<NailSlash>();
             Object.Destroy(originalNailSlash);
 
-            // Locate the damages_enemy FSM and change the attack type to generic.
-            // This will avoid the local player taking knockback from remote players hitting shields etc.
-            var damageFsm = slash.LocateMyFSM("damages_enemy");
-            var takeDamage = damageFsm.GetAction<TakeDamage>("Send Event", 8);
-            takeDamage.AttackType.Value = (int) AttackTypes.Generic;
-            takeDamage = damageFsm.GetAction<TakeDamage>("Parent", 6);
-            takeDamage.AttackType.Value = (int) AttackTypes.Generic;
-            takeDamage = damageFsm.GetAction<TakeDamage>("Grandparent", 6);
-            takeDamage.AttackType.Value = (int) AttackTypes.Generic;
+            ChangeAttackTypeOfFsm(slash);
             
             slash.SetActive(true);
 

--- a/HKMP/Animation/Effects/UpSlash.cs
+++ b/HKMP/Animation/Effects/UpSlash.cs
@@ -7,7 +7,7 @@ namespace HKMP.Animation.Effects {
     public class UpSlash : SlashBase {
         public override void Play(GameObject playerObject, bool[] effectInfo) {
             // Call the base function with the correct parameters
-            Play(playerObject, effectInfo, HeroController.instance.upSlashPrefab, false, true, false);
+            Play(playerObject, effectInfo, HeroController.instance.upSlashPrefab, SlashType.Up);
         }
     }
 }

--- a/HKMP/Animation/Effects/WallSlash.cs
+++ b/HKMP/Animation/Effects/WallSlash.cs
@@ -7,7 +7,7 @@ namespace HKMP.Animation.Effects {
     public class WallSlash : SlashBase {
         public override void Play(GameObject playerObject, bool[] effectInfo) {
             // Call the base function with the correct parameters
-            Play(playerObject, effectInfo, HeroController.instance.wallSlashPrefab, false, false, true);
+            Play(playerObject, effectInfo, HeroController.instance.wallSlashPrefab, SlashType.Wall);
         }
     }
 }

--- a/HKMP/HKMP.cs
+++ b/HKMP/HKMP.cs
@@ -7,8 +7,6 @@ using ModSettings = HKMP.Game.Settings.ModSettings;
 namespace HKMP {
     // Main class of the mod
     public class HKMP : Mod {
-        public static readonly Dictionary<string, GameObject> PreloadedObjects = new Dictionary<string, GameObject>();
-
         // Statically create Settings object, so it can be accessed early
         private ModSettings _modSettings = new ModSettings();
 
@@ -22,11 +20,7 @@ namespace HKMP {
             };
         }
 
-        public override void Initialize(Dictionary<string, Dictionary<string, GameObject>> preloadedObjects) {
-            // Store the preloaded object in a dictionary for easy access
-            PreloadedObjects.Add("HiveKnightSlash",
-                preloadedObjects["GG_Hive_Knight"]["Battle Scene/Hive Knight/Slash 1"]);
-
+        public override void Initialize() {
             // Create a persistent gameObject where we can add the MonoBehaviourUtil to
             var gameObject = new GameObject("HKMP Persistent GameObject");
             Object.DontDestroyOnLoad(gameObject);


### PR DESCRIPTION
To prevent the knockback effect caused by remote players hitting shields and the like, the nail attack animation effect now uses the generic attack type on their HitInstances, which should negate the knockback.