### PR TITLE
Replace objects in lock keywords by dedicated objects

### DIFF
--- a/HKMP/Networking/Client/ClientUpdateManager.cs
+++ b/HKMP/Networking/Client/ClientUpdateManager.cs
@@ -21,13 +21,13 @@ namespace HKMP.Networking.Client {
         }
         
         public override void ResendReliableData(ServerUpdatePacket lostPacket) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.SetLostReliableData(lostPacket);
             }
         }
 
         public void UpdatePlayerPosition(Vector3 position) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.PlayerUpdate);
                 
                 CurrentUpdatePacket.PlayerUpdate.UpdateTypes.Add(PlayerUpdateType.Position);
@@ -36,7 +36,7 @@ namespace HKMP.Networking.Client {
         }
 
         public void UpdatePlayerScale(bool scale) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.PlayerUpdate);
 
                 CurrentUpdatePacket.PlayerUpdate.UpdateTypes.Add(PlayerUpdateType.Scale);
@@ -45,7 +45,7 @@ namespace HKMP.Networking.Client {
         }
 
         public void UpdatePlayerMapPosition(Vector3 mapPosition) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.PlayerUpdate);
 
                 CurrentUpdatePacket.PlayerUpdate.UpdateTypes.Add(PlayerUpdateType.MapPosition);
@@ -54,7 +54,7 @@ namespace HKMP.Networking.Client {
         }
 
         public void UpdatePlayerAnimation(AnimationClip clip, int frame = 0, bool[] effectInfo = null) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.PlayerUpdate);
 
                 CurrentUpdatePacket.PlayerUpdate.UpdateTypes.Add(PlayerUpdateType.Animation);
@@ -95,7 +95,7 @@ namespace HKMP.Networking.Client {
         }
 
         public void UpdateEntityPosition(EntityType entityType, byte entityId, Vector3 position) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.EntityUpdate);
 
                 var entityUpdate = FindOrCreateEntityUpdate(entityType, entityId);
@@ -106,7 +106,7 @@ namespace HKMP.Networking.Client {
         }
 
         public void UpdateEntityState(EntityType entityType, byte entityId, byte state) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.EntityUpdate);
                 
                 var entityUpdate = FindOrCreateEntityUpdate(entityType, entityId);
@@ -117,7 +117,7 @@ namespace HKMP.Networking.Client {
         }
         
         public void UpdateEntityStateAndVariables(EntityType entityType, byte entityId, byte state, List<byte> fsmVariables) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.EntityUpdate);
 
                 var entityUpdate = FindOrCreateEntityUpdate(entityType, entityId);
@@ -131,13 +131,13 @@ namespace HKMP.Networking.Client {
         }
 
         public void SetPlayerDisconnect() {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.PlayerDisconnect);
             }
         }
 
         public void SetTeamUpdate(Team team) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.PlayerTeamUpdate);
 
                 CurrentUpdatePacket.PlayerTeamUpdate.Team = team;
@@ -145,7 +145,7 @@ namespace HKMP.Networking.Client {
         }
 
         public void SetSkinUpdate(byte skinId) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.PlayerSkinUpdate);
 
                 CurrentUpdatePacket.PlayerSkinUpdate.SkinId = skinId;
@@ -153,7 +153,7 @@ namespace HKMP.Networking.Client {
         }
 
         public void SetEmoteUpdate(byte emoteId) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.PlayerEmoteUpdate);
 
                 CurrentUpdatePacket.PlayerEmoteUpdate.EmoteId = emoteId;
@@ -167,7 +167,7 @@ namespace HKMP.Networking.Client {
             bool scale,
             ushort animationClipId
         ) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.HelloServer);
 
                 CurrentUpdatePacket.HelloServer.Username = username;
@@ -184,7 +184,7 @@ namespace HKMP.Networking.Client {
             bool scale,
             ushort animationClipId
         ) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.PlayerEnterScene);
 
                 CurrentUpdatePacket.PlayerEnterScene.NewSceneName = sceneName;
@@ -195,19 +195,19 @@ namespace HKMP.Networking.Client {
         }
 
         public void SetLeftScene() {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.PlayerLeaveScene);
             }
         }
 
         public void SetDisconnect() {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.PlayerDisconnect);
             }
         }
 
         public void SetDeath() {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ServerPacketId.PlayerDeath);
             }
         }

--- a/HKMP/Networking/Server/ServerUpdateManager.cs
+++ b/HKMP/Networking/Server/ServerUpdateManager.cs
@@ -25,13 +25,13 @@ namespace HKMP.Networking.Server {
         }
         
         public override void ResendReliableData(ClientUpdatePacket lostPacket) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.SetLostReliableData(lostPacket);
             }
         }
 
         public void AddPlayerConnectData(ushort id, string username) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerConnect);
 
                 CurrentUpdatePacket.PlayerConnect.DataInstances.Add(new PlayerConnect {
@@ -42,7 +42,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void AddPlayerDisconnectData(ushort id, string username) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerDisconnect);
 
                 CurrentUpdatePacket.PlayerDisconnect.DataInstances.Add(new ClientPlayerDisconnect {
@@ -61,7 +61,7 @@ namespace HKMP.Networking.Server {
             byte skinId,
             ushort animationClipId
         ) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerEnterScene);
 
                 CurrentUpdatePacket.PlayerEnterScene.DataInstances.Add(new ClientPlayerEnterScene {
@@ -85,7 +85,7 @@ namespace HKMP.Networking.Server {
             byte skinId,
             ushort animationClipId
         ) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerAlreadyInScene);
 
                 CurrentUpdatePacket.PlayerAlreadyInScene.PlayerEnterSceneList.Add(new ClientPlayerEnterScene {
@@ -101,7 +101,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void SetAlreadyInSceneHost() {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerAlreadyInScene);
 
                 CurrentUpdatePacket.PlayerAlreadyInScene.SceneHost = true;
@@ -109,7 +109,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void AddPlayerLeaveSceneData(ushort id) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerLeaveScene);
 
                 CurrentUpdatePacket.PlayerLeaveScene.DataInstances.Add(new GenericClientData {
@@ -141,7 +141,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void UpdatePlayerPosition(ushort id, Vector3 position) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerUpdate);
 
                 var playerUpdate = FindOrCreatePlayerUpdate(id);
@@ -152,7 +152,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void UpdatePlayerScale(ushort id, bool scale) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerUpdate);
 
                 var playerUpdate = FindOrCreatePlayerUpdate(id);
@@ -163,7 +163,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void UpdatePlayerMapPosition(ushort id, Vector3 mapPosition) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerUpdate);
 
                 var playerUpdate = FindOrCreatePlayerUpdate(id);
@@ -174,7 +174,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void UpdatePlayerAnimation(ushort id, ushort clipId, byte frame, bool[] effectInfo) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerUpdate);
 
                 var playerUpdate = FindOrCreatePlayerUpdate(id);
@@ -215,7 +215,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void UpdateEntityPosition(EntityType entityType, byte entityId, Vector3 position) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.EntityUpdate);
 
                 var entityUpdate = FindOrCreateEntityUpdate(entityType, entityId);
@@ -226,7 +226,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void UpdateEntityState(EntityType entityType, byte entityId, byte stateIndex) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.EntityUpdate);
 
                 var entityUpdate = FindOrCreateEntityUpdate(entityType, entityId);
@@ -237,7 +237,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void UpdateEntityVariables(EntityType entityType, byte entityId, List<byte> fsmVariables) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.EntityUpdate);
 
                 var entityUpdate = FindOrCreateEntityUpdate(entityType, entityId);
@@ -248,7 +248,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void AddPlayerDeathData(ushort id) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerDeath);
 
                 CurrentUpdatePacket.PlayerDeath.DataInstances.Add(new GenericClientData {
@@ -258,7 +258,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void AddPlayerTeamUpdateData(ushort id, string username, Team team) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerTeamUpdate);
 
                 CurrentUpdatePacket.PlayerTeamUpdate.DataInstances.Add(new ClientPlayerTeamUpdate {
@@ -270,7 +270,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void AddPlayerSkinUpdateData(ushort id, byte skinId) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerSkinUpdate);
                 
                 CurrentUpdatePacket.PlayerSkinUpdate.DataInstances.Add(new ClientPlayerSkinUpdate {
@@ -281,7 +281,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void AddPlayerEmoteUpdateData(ushort id, byte emoteId) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.PlayerEmoteUpdate);
                 
                 CurrentUpdatePacket.PlayerEmoteUpdate.DataInstances.Add(new ClientPlayerEmoteUpdate {
@@ -292,7 +292,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void UpdateGameSettings(Game.Settings.GameSettings gameSettings) {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.GameSettingsUpdated);
 
                 CurrentUpdatePacket.GameSettingsUpdate.GameSettings = gameSettings;
@@ -300,7 +300,7 @@ namespace HKMP.Networking.Server {
         }
 
         public void SetShutdown() {
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.DataPacketIds.Add(ClientPacketId.ServerShutdown);
             }
         }

--- a/HKMP/Networking/UdpUpdateManager.cs
+++ b/HKMP/Networking/UdpUpdateManager.cs
@@ -25,6 +25,7 @@ namespace HKMP.Networking {
 
         private readonly ConcurrentFixedSizeQueue<ushort> _receivedQueue;
 
+        protected readonly object Lock = new object();
         protected TOutgoing CurrentUpdatePacket;
 
         // The current send rate in milliseconds between sending packets
@@ -99,7 +100,7 @@ namespace HKMP.Networking {
             Packet.Packet packet;
             TOutgoing updatePacket;
             
-            lock (CurrentUpdatePacket) {
+            lock (Lock) {
                 CurrentUpdatePacket.Sequence = _localSequence;
                 CurrentUpdatePacket.Ack = _remoteSequence;
                 

--- a/HKMP/Util/ThreadUtil.cs
+++ b/HKMP/Util/ThreadUtil.cs
@@ -4,7 +4,8 @@ using UnityEngine;
 
 namespace HKMP.Util {
     public class ThreadUtil : MonoBehaviour {
-
+        private static readonly object Lock = new object();
+        
         private static readonly List<Action> ActionsToRun = new List<Action>();
 
         public static void Instantiate() {
@@ -14,13 +15,13 @@ namespace HKMP.Util {
         }
         
         public static void RunActionOnMainThread(Action action) {
-            lock (ActionsToRun) {
+            lock (Lock) {
                 ActionsToRun.Add(action);
             }
         }
 
         public void Update() {
-            lock (ActionsToRun) {
+            lock (Lock) {
                 foreach (var action in ActionsToRun) {
                     action.Invoke();
                 }


### PR DESCRIPTION
The lock keywords in the server-side networking code used the packet object which was re-assigned in that same lock. This probably resulted in rare cases where the locks would not properly function and thus desynchronise the state of the packet.
The solution is to use dedicated objects for these locks that are immutable and assigned on class creation.