### PR TITLE
Add server-side setting for allowing skins

### DIFF
--- a/HKMP/Animation/Effects/SlashBase.cs
+++ b/HKMP/Animation/Effects/SlashBase.cs
@@ -201,7 +201,7 @@ namespace HKMP.Animation.Effects {
             Object.Destroy(elegyBeam.LocateMyFSM("damages_enemy"));
             
             // If PvP is enabled, simply add a DamageHero component to the beam
-            var elegyDamage = GameSettings.GrubberyFlyElegyDamage;
+            var elegyDamage = GameSettings.GrubberflyElegyDamage;
             if (GameSettings.IsPvpEnabled && ShouldDoDamage && elegyDamage != 0) {
                 elegyBeam.AddComponent<DamageHero>().damageDealt = elegyDamage;
             }

--- a/HKMP/Game/Client/ClientManager.cs
+++ b/HKMP/Game/Client/ClientManager.cs
@@ -243,6 +243,11 @@ namespace HKMP.Game.Client {
                 return;
             }
 
+            if (!_gameSettings.AllowSkins) {
+                Logger.Info(this, "User changed skin ID, but skins are not allowed by server");
+                return;
+            }
+
             Logger.Info(this, $"Changed local player skin to ID: {skinId}");
 
             // Let the player manager handle the skin updating and send the change to the server
@@ -421,6 +426,7 @@ namespace HKMP.Game.Client {
             var alwaysShowMapChanged = false;
             var onlyCompassChanged = false;
             var teamsChanged = false;
+            var allowSkinsChanged = false;
 
             // Check whether the PvP state changed
             if (_gameSettings.IsPvpEnabled != update.GameSettings.IsPvpEnabled) {
@@ -485,6 +491,16 @@ namespace HKMP.Game.Client {
                 UI.UIManager.InfoBox.AddMessage(message);
                 Logger.Info(this, message);
             }
+            
+            // Check whether allow skins setting changed
+            if (_gameSettings.AllowSkins != update.GameSettings.AllowSkins) {
+                allowSkinsChanged = true;
+                
+                var message = $"Skins are {(update.GameSettings.AllowSkins ? "now" : "no longer")} enabled";
+
+                UI.UIManager.InfoBox.AddMessage(message);
+                Logger.Info(this, message);
+            }
 
             // Update the settings so callbacks can read updated values
             _gameSettings.SetAllProperties(update.GameSettings);
@@ -508,6 +524,11 @@ namespace HKMP.Game.Client {
                 }
 
                 TeamSettingChangeEvent?.Invoke();
+            }
+
+            // If the allow skins setting changed and it is no longer allowed, we reset all existing skins
+            if (allowSkinsChanged && !_gameSettings.AllowSkins) {
+                _playerManager.ResetAllPlayerSkins();
             }
         }
 

--- a/HKMP/Game/Client/PlayerManager.cs
+++ b/HKMP/Game/Client/PlayerManager.cs
@@ -393,6 +393,16 @@ namespace HKMP.Game.Client {
 
             _skinManager.UpdatePlayerSkin(playerData.PlayerObject, skinId);
         }
+
+        public void ResetAllPlayerSkins() {
+            // For each registered player, reset their skin
+            foreach (var playerData in _playerData.Values) {
+                _skinManager.ResetPlayerSkin(playerData.PlayerObject);
+            }
+            
+            // Also reset our local players skin
+            _skinManager.ResetLocalPlayerSkin();
+        }
         
         private void ChangeNameColor(TextMeshPro textMeshObject, Team team) {
             switch (team) {

--- a/HKMP/Game/Client/Skin/SkinManager.cs
+++ b/HKMP/Game/Client/Skin/SkinManager.cs
@@ -87,6 +87,10 @@ namespace HKMP.Game.Client.Skin {
             UpdatePlayerSkin(localPlayerObject, skinId);
         }
 
+        public void ResetPlayerSkin(GameObject playerObject) {
+            UpdatePlayerSkin(playerObject, 0);
+        }
+
         /**
          * Resets the local player skin to the default skin.
          */

--- a/HKMP/Game/Settings/GameSettings.cs
+++ b/HKMP/Game/Settings/GameSettings.cs
@@ -13,21 +13,23 @@
 
         public bool TeamsEnabled { get; set; }
 
-        public int NailDamage { get; set; } = 1;
-        public int GrubberyFlyElegyDamage { get; set; } = 1;
-        public int VengefulSpiritDamage { get; set; } = 1;
-        public int ShadeSoulDamage { get; set; } = 2;
-        public int DesolateDiveDamage { get; set; } = 1;
-        public int DescendingDarkDamage { get; set; } = 2;
-        public int HowlingWraithDamage { get; set; } = 1;
-        public int AbyssShriekDamage { get; set; } = 2;
-        public int GreatSlashDamage { get; set; } = 2;
-        public int DashSlashDamage { get; set; } = 2;
-        public int CycloneSlashDamage { get; set; } = 1;
+        public bool AllowSkins { get; set; } = true;
 
-        public int SporeShroomDamage { get; set; } = 1;
-        public int SporeDungShroomDamage { get; set; } = 1;
-        public int ThornOfAgonyDamage { get; set; } = 1;
+        public byte NailDamage { get; set; } = 1;
+        public byte GrubberflyElegyDamage { get; set; } = 1;
+        public byte VengefulSpiritDamage { get; set; } = 1;
+        public byte ShadeSoulDamage { get; set; } = 2;
+        public byte DesolateDiveDamage { get; set; } = 1;
+        public byte DescendingDarkDamage { get; set; } = 2;
+        public byte HowlingWraithDamage { get; set; } = 1;
+        public byte AbyssShriekDamage { get; set; } = 2;
+        public byte GreatSlashDamage { get; set; } = 2;
+        public byte DashSlashDamage { get; set; } = 2;
+        public byte CycloneSlashDamage { get; set; } = 1;
+
+        public byte SporeShroomDamage { get; set; } = 1;
+        public byte SporeDungShroomDamage { get; set; } = 1;
+        public byte ThornOfAgonyDamage { get; set; } = 1;
 
         public void SetAllProperties(GameSettings gameSettings) {
             // Use reflection to copy over all properties into this object

--- a/HKMP/HKMP.cs
+++ b/HKMP/HKMP.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using HKMP.Util;
+﻿using HKMP.Util;
 using Modding;
 using UnityEngine;
 using ModSettings = HKMP.Game.Settings.ModSettings;
@@ -12,12 +11,6 @@ namespace HKMP {
 
         public override string GetVersion() {
             return "0.5.0";
-        }
-
-        public override List<(string, string)> GetPreloadNames() {
-            return new List<(string, string)> {
-                ("GG_Hive_Knight", "Battle Scene/Hive Knight/Slash 1")
-            };
         }
 
         public override void Initialize() {

--- a/HKMP/Networking/Packet/Data/GameSettingsUpdate.cs
+++ b/HKMP/Networking/Packet/Data/GameSettingsUpdate.cs
@@ -1,5 +1,6 @@
 ﻿namespace HKMP.Networking.Packet.Data {
     public class GameSettingsUpdate : IPacketData {
+        // TODO: optimize this by only sending the values that actually changed
 
         public Game.Settings.GameSettings GameSettings { get; set; }
 
@@ -12,8 +13,8 @@
 
                 if (prop.PropertyType == typeof(bool)) {
                     packet.Write((bool) prop.GetValue(GameSettings, null));
-                } else if (prop.PropertyType == typeof(int)) {
-                    packet.Write((int) prop.GetValue(GameSettings, null));
+                } else if (prop.PropertyType == typeof(byte)) {
+                    packet.Write((byte) prop.GetValue(GameSettings, null));
                 } else {
                     Logger.Warn(this, $"No write handler for property type: {prop.GetType()}");
                 }
@@ -32,8 +33,8 @@
                 // ReSharper disable once OperatorIsCanBeUsed
                 if (prop.PropertyType == typeof(bool)) {
                     prop.SetValue(GameSettings, packet.ReadBool(), null);
-                } else if (prop.PropertyType == typeof(int)) {
-                    prop.SetValue(GameSettings, packet.ReadInt(), null);
+                } else if (prop.PropertyType == typeof(byte)) {
+                    prop.SetValue(GameSettings, packet.ReadByte(), null);
                 } else {
                     Logger.Warn(this, $"No read handler for property type: {prop.GetType()}");
                 }

--- a/HKMP/UI/ClientSettingsUI.cs
+++ b/HKMP/UI/ClientSettingsUI.cs
@@ -122,16 +122,11 @@ namespace HKMP.UI {
                 _settingsUiObject,
                 new Vector2(x, y),
                 "Player skin ID",
-                typeof(int),
+                typeof(byte),
                 0,
                 0,
                 o => {
-                    var value = (int) o;
-                    if (value >= 0 && value < 256) {
-                        _clientManager.ChangeSkin((byte) value);
-                    } else {
-                        // TODO: somehow notify the user that this is an invalid ID
-                    }
+                    _clientManager.ChangeSkin((byte) o);
                 }
             );
 

--- a/HKMP/UI/ServerSettingsUI.cs
+++ b/HKMP/UI/ServerSettingsUI.cs
@@ -211,102 +211,109 @@ namespace HKMP.UI {
                     o => _gameSettings.TeamsEnabled = (bool) o
                 ),
                 new SettingsEntry(
+                    "Allow skins",
+                    typeof(bool),
+                    true,
+                    _gameSettings.AllowSkins,
+                    o => _gameSettings.AllowSkins = (bool) o
+                ),
+                new SettingsEntry(
                     "Nail damage",
-                    typeof(int),
+                    typeof(byte),
                     1,
                     _gameSettings.NailDamage,
-                    o => _gameSettings.NailDamage = (int) o
+                    o => _gameSettings.NailDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Grubberfly's Elegy beam damage",
-                    typeof(int),
+                    typeof(byte),
                     1,
-                    _gameSettings.GrubberyFlyElegyDamage,
-                    o => _gameSettings.GrubberyFlyElegyDamage = (int) o
+                    _gameSettings.GrubberflyElegyDamage,
+                    o => _gameSettings.GrubberflyElegyDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Vengeful Spirit damage",
-                    typeof(int),
+                    typeof(byte),
                     1,
                     _gameSettings.VengefulSpiritDamage,
-                    o => _gameSettings.VengefulSpiritDamage = (int) o
+                    o => _gameSettings.VengefulSpiritDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Shade Soul damage",
-                    typeof(int),
+                    typeof(byte),
                     2,
                     _gameSettings.ShadeSoulDamage,
-                    o => _gameSettings.ShadeSoulDamage = (int) o
+                    o => _gameSettings.ShadeSoulDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Desolate Dive damage",
-                    typeof(int),
+                    typeof(byte),
                     1,
                     _gameSettings.DesolateDiveDamage,
-                    o => _gameSettings.DesolateDiveDamage = (int) o
+                    o => _gameSettings.DesolateDiveDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Descending Dark damage",
-                    typeof(int),
+                    typeof(byte),
                     2,
                     _gameSettings.DescendingDarkDamage,
-                    o => _gameSettings.DescendingDarkDamage = (int) o
+                    o => _gameSettings.DescendingDarkDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Howling Wraiths damage",
-                    typeof(int),
+                    typeof(byte),
                     1,
                     _gameSettings.HowlingWraithDamage,
-                    o => _gameSettings.HowlingWraithDamage = (int) o
+                    o => _gameSettings.HowlingWraithDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Abyss Shriek damage",
-                    typeof(int),
+                    typeof(byte),
                     2,
                     _gameSettings.AbyssShriekDamage,
-                    o => _gameSettings.AbyssShriekDamage = (int) o
+                    o => _gameSettings.AbyssShriekDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Great Slash damage",
-                    typeof(int),
+                    typeof(byte),
                     2,
                     _gameSettings.GreatSlashDamage,
-                    o => _gameSettings.GreatSlashDamage = (int) o
+                    o => _gameSettings.GreatSlashDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Dash Slash damage",
-                    typeof(int),
+                    typeof(byte),
                     2,
                     _gameSettings.DashSlashDamage,
-                    o => _gameSettings.DashSlashDamage = (int) o
+                    o => _gameSettings.DashSlashDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Cyclone Slash damage",
-                    typeof(int),
+                    typeof(byte),
                     1,
                     _gameSettings.CycloneSlashDamage,
-                    o => _gameSettings.CycloneSlashDamage = (int) o
+                    o => _gameSettings.CycloneSlashDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Spore Shroom cloud damage",
-                    typeof(int),
+                    typeof(byte),
                     1,
                     _gameSettings.SporeShroomDamage,
-                    o => _gameSettings.SporeShroomDamage = (int) o
+                    o => _gameSettings.SporeShroomDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Spore Dung Shroom cloud damage",
-                    typeof(int),
+                    typeof(byte),
                     1,
                     _gameSettings.SporeDungShroomDamage,
-                    o => _gameSettings.SporeDungShroomDamage = (int) o
+                    o => _gameSettings.SporeDungShroomDamage = (byte) o
                 ),
                 new SettingsEntry(
                     "Thorns of Agony damage",
-                    typeof(int),
+                    typeof(byte),
                     1,
                     _gameSettings.ThornOfAgonyDamage,
-                    o => _gameSettings.ThornOfAgonyDamage = (int) o
+                    o => _gameSettings.ThornOfAgonyDamage = (byte) o
                 ),
             };
         }

--- a/HKMP/UI/SettingsUIEntry.cs
+++ b/HKMP/UI/SettingsUIEntry.cs
@@ -44,7 +44,7 @@ namespace HKMP.UI {
                 alignment: TextAnchor.LowerLeft
             );
 
-            if (type == typeof(int)) {
+            if (type == typeof(byte)) {
                 _input = new InputComponent(
                     parent,
                     position - new Vector2(0, 35 + (doubleLine ? 25 : 0)),
@@ -92,12 +92,14 @@ namespace HKMP.UI {
                     FontManager.UIFontRegular,
                     alignment: TextAnchor.MiddleLeft
                 );
+            } else {
+                throw new ArgumentException("Type of object is not supported");
             }
         }
 
         public void ApplySetting() {
-            if (_type == typeof(int)) {
-                if (!int.TryParse(_input.GetInput(), out var intValue)) {
+            if (_type == typeof(byte)) {
+                if (!byte.TryParse(_input.GetInput(), out var intValue)) {
                     _applySetting(_defaultValue);
                     return;
                 }


### PR DESCRIPTION
The server-side setting will dictate whether skins are enabled for clients or not. If disabled, clients will not be able to change their skin locally nor broadcast them to other clients. Moreover, on disabling the setting, all clients will revert their skin to the default. Enabling the setting again will not reapply the skins and clients must apply their client setting again to display their skin.