### PR TITLE
Rework UI to handle different startup resolutions

### DIFF
--- a/HKMP/HKMP.csproj
+++ b/HKMP/HKMP.csproj
@@ -182,6 +182,7 @@
         <Compile Include="UI\SettingsEntry.cs" />
         <Compile Include="UI\ServerSettingsUI.cs" />
         <Compile Include="UI\SettingsUIEntry.cs" />
+        <Compile Include="UI\UIGroup.cs" />
         <Compile Include="Util\AudioUtil.cs" />
         <Compile Include="Util\CopyUtil.cs" />
         <Compile Include="Util\CoroutineCancelComponent.cs" />

--- a/HKMP/UI/ClientSettingsUI.cs
+++ b/HKMP/UI/ClientSettingsUI.cs
@@ -11,8 +11,8 @@ namespace HKMP.UI {
         private readonly Game.Settings.GameSettings _clientGameSettings;
         private readonly ClientManager _clientManager;
 
-        private readonly GameObject _settingsUiObject;
-        private readonly GameObject _connectUiObject;
+        private readonly UIGroup _settingsGroup;
+        private readonly UIGroup _connectGroup;
 
         private readonly PingUI _pingUi;
 
@@ -20,16 +20,16 @@ namespace HKMP.UI {
             ModSettings modSettings,
             Game.Settings.GameSettings clientGameSettings,
             ClientManager clientManager,
-            GameObject settingsUiObject, 
-            GameObject connectUiObject,
+            UIGroup settingsGroup, 
+            UIGroup connectGroup,
             PingUI pingUi
         ) {
             _modSettings = modSettings;
             _clientManager = clientManager;
             _clientGameSettings = clientGameSettings;
             
-            _settingsUiObject = settingsUiObject;
-            _connectUiObject = connectUiObject;
+            _settingsGroup = settingsGroup;
+            _connectGroup = connectGroup;
 
             _pingUi = pingUi;
             
@@ -37,10 +37,10 @@ namespace HKMP.UI {
         }
 
         private void CreateSettingsUI() {
-            _settingsUiObject.SetActive(false);
+            _settingsGroup.SetActive(false);
 
-            var x = Screen.width - 210f;
-            var y = Screen.height - 75f;
+            var x = 1920f - 210f;
+            var y = 1080f - 75f;
             
             CreateTeamSelectionUI(x, ref y);
             
@@ -49,18 +49,18 @@ namespace HKMP.UI {
             CreatePingUiToggle(x, ref y);
             
             new ButtonComponent(
-                _settingsUiObject,
+                _settingsGroup,
                 new Vector2(x, y),
                 "Back"
             ).SetOnPress(() => {
-                _settingsUiObject.SetActive(false);
-                _connectUiObject.SetActive(true);
+                _settingsGroup.SetActive(false);
+                _connectGroup.SetActive(true);
             });
         }
 
         private void CreateTeamSelectionUI(float x, ref float y) {
             new TextComponent(
-                _settingsUiObject,
+                _settingsGroup,
                 new Vector2(x, y),
                 new Vector2(200, 30),
                 "Team Selection",
@@ -71,7 +71,7 @@ namespace HKMP.UI {
             y -= 35;
 
             var radioButtonBox = new RadioButtonBoxComponent(
-                _settingsUiObject,
+                _settingsGroup,
                 new Vector2(x, y),
                 new Vector2(300, 35),
                 new[] {
@@ -119,7 +119,7 @@ namespace HKMP.UI {
 
         private void CreateSkinSelectionUI(float x, ref float y) {
             var skinSetting = new SettingsUIEntry(
-                _settingsUiObject,
+                _settingsGroup,
                 new Vector2(x, y),
                 "Player skin ID",
                 typeof(byte),
@@ -133,7 +133,7 @@ namespace HKMP.UI {
             y -= 100;
 
             new ButtonComponent(
-                _settingsUiObject,
+                _settingsGroup,
                 new Vector2(x, y),
                 "Apply skin"
             ).SetOnPress(skinSetting.ApplySetting);
@@ -143,7 +143,7 @@ namespace HKMP.UI {
 
         private void CreatePingUiToggle(float x, ref float y) {
             new SettingsUIEntry(
-                _settingsUiObject,
+                _settingsGroup,
                 new Vector2(x, y),
                 "Display ping",
                 typeof(bool),

--- a/HKMP/UI/Component/ButtonComponent.cs
+++ b/HKMP/UI/Component/ButtonComponent.cs
@@ -8,14 +8,50 @@ namespace HKMP.UI.Component {
     public class ButtonComponent : Component, IButtonComponent {
         private Action _onPress;
 
-        public ButtonComponent(GameObject parent, Vector2 position, string text) : this(parent, position,
-            new Vector2(200, 30), text, TextureManager.ButtonBackground,
-            FontManager.UIFontRegular, 16) {
+        public ButtonComponent(
+            UIGroup uiGroup,
+            Vector2 position,
+            string text
+        ) : this(
+            uiGroup,
+            position,
+            new Vector2(200, 30),
+            text,
+            TextureManager.ButtonBackground,
+            FontManager.UIFontRegular,
+            16) {
         }
 
-        public ButtonComponent(GameObject parent, Vector2 position, Vector2 size, string text, Texture2D texture,
+        public ButtonComponent(
+            UIGroup uiGroup,
+            Vector2 position,
+            Vector2 size,
+            string text,
+            Texture2D texture,
             Font font,
-            int fontSize = 13) : base(parent, position, size) {
+            int fontSize = 13
+        ) : this(
+            uiGroup,
+            position,
+            size,
+            text,
+            texture,
+            font,
+            Color.white,
+            fontSize
+        ) {
+        }
+
+        public ButtonComponent(
+            UIGroup uiGroup, 
+            Vector2 position, 
+            Vector2 size,
+            string text, 
+            Texture2D texture,
+            Font font,
+            Color textColor,
+            int fontSize = 13
+        ) : base(uiGroup, position, size) {
             // Create background image
             var image = GameObject.AddComponent<Image>();
             image.sprite = CreateSpriteFromTexture(texture);
@@ -29,6 +65,7 @@ namespace HKMP.UI.Component {
             textComponent.font = font;
             textComponent.fontSize = fontSize;
             textComponent.alignment = TextAnchor.MiddleCenter;
+            textComponent.color = textColor;
 
             var textTransform = textComponent.transform;
             var textPosition = textTransform.position;

--- a/HKMP/UI/Component/CheckboxComponent.cs
+++ b/HKMP/UI/Component/CheckboxComponent.cs
@@ -7,8 +7,8 @@ namespace HKMP.UI.Component {
         
         private OnToggle _onToggle;
         
-        public CheckboxComponent(GameObject parent, Vector2 position, Vector2 size, bool defaultValue, Texture2D backgroundTexture, Texture2D checkTexture) :
-            base(parent, position, size) {
+        public CheckboxComponent(UIGroup uiGroup, Vector2 position, Vector2 size, bool defaultValue, Texture2D backgroundTexture, Texture2D checkTexture) :
+            base(uiGroup, position, size) {
             // Create the toggle component
             ToggleComponent = GameObject.AddComponent<Toggle>();
             ToggleComponent.transition = Selectable.Transition.ColorTint;

--- a/HKMP/UI/Component/Component.cs
+++ b/HKMP/UI/Component/Component.cs
@@ -6,7 +6,11 @@ namespace HKMP.UI.Component {
 
         private readonly RectTransform _transform;
 
-        protected Component(GameObject parent, Vector2 position, Vector2 size) {
+        private bool _activeSelf;
+        
+        public UIGroup UiGroup { private get; set; }
+
+        protected Component(UIGroup uiGroup, Vector2 position, Vector2 size) {
             // Create a gameobject with the CanvasRenderer component, so we can render as GUI
             GameObject = new GameObject();
             GameObject.AddComponent<CanvasRenderer>();
@@ -15,14 +19,31 @@ namespace HKMP.UI.Component {
 
             // Create a RectTransform with the desired size
             _transform = GameObject.AddComponent<RectTransform>();
-            _transform.position = position;
+
+            position = new Vector2(
+                position.x / 1920f,
+                position.y / 1080f
+            );
+            _transform.anchorMin = _transform.anchorMax = position;
+            
             _transform.sizeDelta = size;
             
-            GameObject.transform.SetParent(parent.transform, false);
+            GameObject.transform.SetParent(UIManager.UiGameObject.transform, false);
+
+            _activeSelf = true;
+
+            UiGroup = uiGroup;
+            uiGroup?.AddComponent(this);
+        }
+
+        public void SetGroupActive(bool groupActive) {
+            GameObject.SetActive(_activeSelf && groupActive);
         }
 
         public void SetActive(bool active) {
-            GameObject.SetActive(active);
+            _activeSelf = active;
+            
+            GameObject.SetActive(_activeSelf && UiGroup.IsActive());
         }
 
         public Vector2 GetPosition() {

--- a/HKMP/UI/Component/DividerComponent.cs
+++ b/HKMP/UI/Component/DividerComponent.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 namespace HKMP.UI.Component {
     public class DividerComponent : Component {
         
-        public DividerComponent(GameObject parent, Vector2 position, Vector2 size) : base(parent, position, size) {
+        public DividerComponent(UIGroup uiGroup, Vector2 position, Vector2 size) : base(uiGroup, position, size) {
             var image = GameObject.AddComponent<Image>();
             image.sprite = CreateSpriteFromTexture(TextureManager.Divider);
             image.type = Image.Type.Simple;

--- a/HKMP/UI/Component/HiddenButtonLeaveHandler.cs
+++ b/HKMP/UI/Component/HiddenButtonLeaveHandler.cs
@@ -1,15 +1,14 @@
+using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
 namespace HKMP.UI.Component {
     public class HiddenButtonLeaveHandler : MonoBehaviour, IPointerExitHandler {
         
-        public GameObject DeactivateObject { get; set; }
-        public GameObject ActivateObject { get; set; }
+        public Action Action { private get; set; }
         
         public void OnPointerExit(PointerEventData eventData) {
-            DeactivateObject.SetActive(false);
-            ActivateObject.SetActive(true);
+            Action.Invoke();
         }
     }
 }

--- a/HKMP/UI/Component/HiddenInputComponent.cs
+++ b/HKMP/UI/Component/HiddenInputComponent.cs
@@ -5,14 +5,14 @@ using UnityEngine.UI;
 namespace HKMP.UI.Component {
     public class HiddenInputComponent : InputComponent {
         public HiddenInputComponent(
-            GameObject parent, 
+            UIGroup uiGroup, 
             Vector2 position, 
             string defaultValue, 
             string placeholderText, 
             int fontSize = 18, 
             InputField.CharacterValidation characterValidation = InputField.CharacterValidation.None
         ) : this(
-            parent, 
+            uiGroup, 
             position,
             new Vector2(200, 30),
             defaultValue, 
@@ -25,7 +25,7 @@ namespace HKMP.UI.Component {
         }
 
         public HiddenInputComponent(
-            GameObject parent, 
+            UIGroup uiGroup, 
             Vector2 position, 
             Vector2 size, 
             string defaultValue, 
@@ -35,7 +35,7 @@ namespace HKMP.UI.Component {
             int fontSize = 13, 
             InputField.CharacterValidation characterValidation = InputField.CharacterValidation.None
         ) : base(
-            parent, 
+            uiGroup, 
             position, 
             size, 
             defaultValue, 
@@ -45,54 +45,32 @@ namespace HKMP.UI.Component {
             fontSize, 
             characterValidation
         ) {
-            // Create a new object so we can switch between the block object
-            // and the input object to manage the hidden state
-            var blockObject = new GameObject();
-            blockObject.AddComponent<CanvasRenderer>();
-            Object.DontDestroyOnLoad(blockObject);
-            
-            var rectTransform = blockObject.AddComponent<RectTransform>();
-            rectTransform.position = position;
-            rectTransform.sizeDelta = size;
-            
-            blockObject.transform.SetParent(parent.transform);
-
-            // Add the background image to the block object
-            var blockImage = blockObject.AddComponent<Image>();
-            blockImage.sprite = CreateSpriteFromTexture(texture);
-            blockImage.type = Image.Type.Simple;
-
-            // Add the show text to the block object
-            var showText = new GameObject();
-            showText.AddComponent<RectTransform>().sizeDelta = size;
-            var placeholderTextComponent = showText.AddComponent<Text>();
-            placeholderTextComponent.text = "Click to show";
-            placeholderTextComponent.font = font;
-            placeholderTextComponent.fontSize = fontSize;
-            placeholderTextComponent.alignment = TextAnchor.MiddleCenter;
-            placeholderTextComponent.color = new Color(0, 0, 0, 0.5f);
-
-            // Set the transform parent
-            showText.transform.SetParent(blockObject.transform, false);
-            Object.DontDestroyOnLoad(showText);
+            var buttonComponent = new ButtonComponent(
+                uiGroup,
+                position,
+                size,
+                "Click to show",
+                texture,
+                font,
+                new Color(0, 0, 0, 0.5f),
+                fontSize
+            );
             
             // Disable the original input component object
             GameObject.SetActive(false);
 
-            // Add a button component so we can click it to show the input component
-            var blockButton = blockObject.AddComponent<Button>();
-            
             // Hide our block object and show the input component on click
-            blockButton.onClick.AddListener(() => {
-                blockObject.SetActive(false);
+            buttonComponent.SetOnPress(() => {
+                buttonComponent.SetActive(false);
                 GameObject.SetActive(true);
             });
             
             // Add a handler for when we leave the component with our cursor,
             // which is when we enable the block object again and hide the input component
-            var hiddenButtonLeaveHandler = GameObject.AddComponent<HiddenButtonLeaveHandler>();
-            hiddenButtonLeaveHandler.DeactivateObject = GameObject;
-            hiddenButtonLeaveHandler.ActivateObject = blockObject;
+            GameObject.AddComponent<HiddenButtonLeaveHandler>().Action = () => {
+                buttonComponent.SetActive(true);
+                GameObject.SetActive(false);
+            };
         }
     }
 }

--- a/HKMP/UI/Component/IComponent.cs
+++ b/HKMP/UI/Component/IComponent.cs
@@ -2,6 +2,8 @@
 
 namespace HKMP.UI.Component {
     public interface IComponent {
+        void SetGroupActive(bool groupActive);
+        
         void SetActive(bool active);
 
         Vector2 GetPosition();

--- a/HKMP/UI/Component/ImageComponent.cs
+++ b/HKMP/UI/Component/ImageComponent.cs
@@ -4,11 +4,11 @@ using UnityEngine.UI;
 namespace HKMP.UI.Component {
     public class ImageComponent : Component {
         public ImageComponent(
-            GameObject parent, 
+            UIGroup uiGroup, 
             Vector2 position, 
             Vector2 size,
             Texture2D texture
-        ) : base(parent, position, size) {
+        ) : base(uiGroup, position, size) {
             var image = GameObject.AddComponent<Image>();
             image.sprite = CreateSpriteFromTexture(texture);
             image.type = Image.Type.Simple;

--- a/HKMP/UI/Component/InputComponent.cs
+++ b/HKMP/UI/Component/InputComponent.cs
@@ -6,15 +6,37 @@ namespace HKMP.UI.Component {
     public class InputComponent : Component, IInputComponent {
         private readonly Text _textObject;
 
-        public InputComponent(GameObject parent, Vector2 position, string defaultValue, string placeholderText, int fontSize = 18, InputField.CharacterValidation characterValidation = InputField.CharacterValidation.None) :
-            this(parent, position, new Vector2(200, 30), defaultValue, placeholderText,
-                TextureManager.InputFieldBackground, FontManager.UIFontRegular, fontSize, characterValidation) {
+        public InputComponent(
+            UIGroup uiGroup, 
+            Vector2 position, 
+            string defaultValue, 
+            string placeholderText, 
+            int fontSize = 18, 
+            InputField.CharacterValidation characterValidation = InputField.CharacterValidation.None
+        ) : this(
+                uiGroup, 
+                position, 
+                new Vector2(200, 30), 
+                defaultValue, 
+                placeholderText,
+                TextureManager.InputFieldBackground, 
+                FontManager.UIFontRegular, 
+                fontSize, 
+                characterValidation
+        ) {
         }
 
-        public InputComponent(GameObject parent, Vector2 position, Vector2 size, string defaultValue,
-            string placeholderText, Texture2D texture, Font font,
-            int fontSize = 13, InputField.CharacterValidation characterValidation = InputField.CharacterValidation.None)
-            : base(parent, position, size) {
+        public InputComponent(
+            UIGroup uiGroup, 
+            Vector2 position, 
+            Vector2 size, 
+            string defaultValue,
+            string placeholderText, 
+            Texture2D texture, 
+            Font font,
+            int fontSize = 13, 
+            InputField.CharacterValidation characterValidation = InputField.CharacterValidation.None
+        ) : base(uiGroup, position, size) {
             // Create background image
             var image = GameObject.AddComponent<Image>();
             image.sprite = CreateSpriteFromTexture(texture);

--- a/HKMP/UI/Component/RadioButtonBoxComponent.cs
+++ b/HKMP/UI/Component/RadioButtonBoxComponent.cs
@@ -15,16 +15,16 @@ namespace HKMP.UI.Component {
         private OnValueChange _onValueChange;
 
         public RadioButtonBoxComponent(
-            GameObject parent,
+            UIGroup uiGroup,
             Vector2 position,
             Vector2 size,
             string[] labels,
             int defaultValue
-        ) : base (parent, position, size) {
+        ) : base (uiGroup, position, size) {
             _defaultValue = defaultValue;
             
             var tempGameObject = new GameObject();
-            tempGameObject.transform.SetParent(parent.transform);
+            tempGameObject.transform.SetParent(UIManager.UiGameObject.transform);
             tempGameObject.SetActive(true);
             
             _toggleGroup = tempGameObject.AddComponent<ToggleGroup>();
@@ -38,7 +38,7 @@ namespace HKMP.UI.Component {
                 var label = labels[i];
 
                 new TextComponent(
-                    parent,
+                    uiGroup,
                     position,
                     new Vector2(TextWidth, 30),
                     label,
@@ -48,7 +48,7 @@ namespace HKMP.UI.Component {
                 );
 
                 var checkboxComponent = new CheckboxComponent(
-                    parent,
+                    uiGroup,
                     position + new Vector2(90, 0),
                     new Vector2(20, 20),
                     i == defaultValue,

--- a/HKMP/UI/Component/TextComponent.cs
+++ b/HKMP/UI/Component/TextComponent.cs
@@ -5,8 +5,16 @@ namespace HKMP.UI.Component {
     public class TextComponent : Component, ITextComponent {
         private readonly Text _textObject;
         
-        public TextComponent(GameObject parent, Vector2 position, Vector2 size, string text, Font font, int fontSize = 13,
-            FontStyle fontStyle = FontStyle.Normal, TextAnchor alignment = TextAnchor.MiddleCenter) : base(parent, position, size) {
+        public TextComponent(
+            UIGroup uiGroup, 
+            Vector2 position, 
+            Vector2 size, 
+            string text,
+            Font font,
+            int fontSize = 13,
+            FontStyle fontStyle = FontStyle.Normal,
+            TextAnchor alignment = TextAnchor.MiddleCenter
+        ) : base(uiGroup, position, size) {
             // Create the unity text object and set the corresponding details
             _textObject = GameObject.AddComponent<Text>();
             _textObject.text = text;

--- a/HKMP/UI/ConnectUI.cs
+++ b/HKMP/UI/ConnectUI.cs
@@ -12,9 +12,9 @@ namespace HKMP.UI {
         private readonly ClientManager _clientManager;
         private readonly ServerManager _serverManager;
 
-        private readonly GameObject _connectUiObject;
-        private readonly GameObject _clientSettingsUiObject;
-        private readonly GameObject _serverSettingsUiObject;
+        private readonly UIGroup _connectGroup;
+        private readonly UIGroup _clientSettingsGroup;
+        private readonly UIGroup _serverSettingsGroup;
 
         private IInputComponent _addressInput;
         private IInputComponent _portInput;
@@ -35,17 +35,17 @@ namespace HKMP.UI {
             ModSettings modSettings, 
             ClientManager clientManager, 
             ServerManager serverManager,
-            GameObject connectUiObject,
-            GameObject clientSettingsUiObject,
-            GameObject serverSettingsUiObject
+            UIGroup connectGroup,
+            UIGroup clientSettingsGroup,
+            UIGroup serverSettingsGroup
         ) {
             _modSettings = modSettings;
             _clientManager = clientManager;
             _serverManager = serverManager;
 
-            _connectUiObject = connectUiObject;
-            _clientSettingsUiObject = clientSettingsUiObject;
-            _serverSettingsUiObject = serverSettingsUiObject;
+            _connectGroup = connectGroup;
+            _clientSettingsGroup = clientSettingsGroup;
+            _serverSettingsGroup = serverSettingsGroup;
             
             CreateConnectUI();
         }
@@ -53,11 +53,11 @@ namespace HKMP.UI {
         private void CreateConnectUI() {
             // Now we can start adding individual components to our UI
             // Keep track of current x and y of objects we want to place
-            var x = Screen.width - 210.0f;
-            var y = Screen.height - 75.0f;
+            var x = 1920f - 210.0f;
+            var y = 1080f - 75.0f;
 
-            var multiplayerText = new TextComponent(
-                _connectUiObject,
+            new TextComponent(
+                _connectGroup,
                 new Vector2(x, y),
                 new Vector2(200, 30),
                 "Multiplayer",
@@ -68,15 +68,15 @@ namespace HKMP.UI {
             y -= 30;
 
             new DividerComponent(
-                _connectUiObject,
+                _connectGroup,
                 new Vector2(x, y),
                 new Vector2(200, 1)
             );
 
             y -= 30;
 
-            var joinText = new TextComponent(
-                _connectUiObject,
+            new TextComponent(
+                _connectGroup,
                 new Vector2(x, y),
                 new Vector2(200, 30),
                 "Join Server",
@@ -87,7 +87,7 @@ namespace HKMP.UI {
             y -= 40;
 
             _addressInput = new HiddenInputComponent(
-                _connectUiObject,
+                _connectGroup,
                 new Vector2(x, y),
                 _modSettings.JoinAddress,
                 "IP Address"
@@ -97,7 +97,7 @@ namespace HKMP.UI {
 
             var joinPort = _modSettings.JoinPort;
             _portInput = new InputComponent(
-                _connectUiObject,
+                _connectGroup,
                 new Vector2(x, y),
                 joinPort == -1 ? "" : joinPort.ToString(),
                 "Port",
@@ -108,7 +108,7 @@ namespace HKMP.UI {
 
             var username = _modSettings.Username;
             _usernameInput = new InputComponent(
-                _connectUiObject,
+                _connectGroup,
                 new Vector2(x, y),
                 username,
                 "Username"
@@ -116,26 +116,27 @@ namespace HKMP.UI {
 
             y -= 40;
             
-            new ButtonComponent(
-                _connectUiObject,
+            var clientSettingsButton = new ButtonComponent(
+                _connectGroup,
                 new Vector2(x, y),
                 "Settings"
-            ).SetOnPress(() => {
-                _connectUiObject.SetActive(false);
-                _clientSettingsUiObject.SetActive(true);
+            );
+            clientSettingsButton.SetOnPress(() => {
+                _connectGroup.SetActive(false);
+                _clientSettingsGroup.SetActive(true);
             });
 
             y -= 40;
 
             _connectButton = new ButtonComponent(
-                _connectUiObject,
+                _connectGroup,
                 new Vector2(x, y),
                 "Connect"
             );
             _connectButton.SetOnPress(OnConnectButtonPressed);
-
+            
             _disconnectButton = new ButtonComponent(
-                _connectUiObject,
+                _connectGroup,
                 new Vector2(x, y),
                 "Disconnect"
             );
@@ -145,7 +146,7 @@ namespace HKMP.UI {
             y -= 40;
 
             _clientFeedbackText = new TextComponent(
-                _connectUiObject,
+                _connectGroup,
                 new Vector2(x, y),
                 new Vector2(200, 30),
                 "",
@@ -157,15 +158,15 @@ namespace HKMP.UI {
             y -= 30;
 
             new DividerComponent(
-                _connectUiObject,
+                _connectGroup,
                 new Vector2(x, y),
                 new Vector2(200, 1)
             );
 
             y -= 30;
 
-            var hostText = new TextComponent(
-                _connectUiObject,
+            new TextComponent(
+                _connectGroup,
                 new Vector2(x, y),
                 new Vector2(200, 30),
                 "Host Server",
@@ -175,26 +176,27 @@ namespace HKMP.UI {
             
             y -= 40;
 
-            new ButtonComponent(
-                _connectUiObject,
+            var serverSettingsButton = new ButtonComponent(
+                _connectGroup,
                 new Vector2(x, y),
                 "Host Settings"
-            ).SetOnPress(() => {
-                _connectUiObject.SetActive(false);
-                _serverSettingsUiObject.SetActive(true);
+            );
+            serverSettingsButton.SetOnPress(() => {
+                _connectGroup.SetActive(false);
+                _serverSettingsGroup.SetActive(true);
             });
 
             y -= 40;
 
             _startButton = new ButtonComponent(
-                _connectUiObject,
+                _connectGroup,
                 new Vector2(x, y),
                 "Start Hosting"
             );
             _startButton.SetOnPress(OnStartButtonPressed);
 
             _stopButton = new ButtonComponent(
-                _connectUiObject,
+                _connectGroup,
                 new Vector2(x, y),
                 "Stop Hosting"
             );
@@ -204,7 +206,7 @@ namespace HKMP.UI {
             y -= 40;
 
             _serverFeedbackText = new TextComponent(
-                _connectUiObject,
+                _connectGroup,
                 new Vector2(x, y),
                 new Vector2(200, 30),
                 "",

--- a/HKMP/UI/InfoBoxUI.cs
+++ b/HKMP/UI/InfoBoxUI.cs
@@ -22,11 +22,11 @@ namespace HKMP.UI {
         // The margin of the info box with the borders of the screen
         private const int InfoBoxMargin = 50;
 
-        private readonly GameObject _infoBoxUiObject;
+        private readonly UIGroup _infoBoxGroup;
         private readonly TextComponent[] _messages;
 
-        public InfoBoxUI(GameObject infoBoxUiObject) {
-            _infoBoxUiObject = infoBoxUiObject;
+        public InfoBoxUI(UIGroup infoBoxGroup) {
+            _infoBoxGroup = infoBoxGroup;
 
             _messages = new TextComponent[MaxMessages];
         }
@@ -76,7 +76,7 @@ namespace HKMP.UI {
                 _messages[i + 1] = messageObject;
             }
 
-            var newMessageObject = CreateMessageObject(messageText, new Vector2(Screen.width - InfoBoxWidth / 2 - InfoBoxMargin, InfoBoxMargin));
+            var newMessageObject = CreateMessageObject(messageText, new Vector2(1920f - InfoBoxWidth / 2 - InfoBoxMargin, InfoBoxMargin));
             _messages[0] = newMessageObject;
             
             MonoBehaviourUtil.Instance.StartCoroutine(WaitMessageStay(newMessageObject));
@@ -84,7 +84,7 @@ namespace HKMP.UI {
 
         private TextComponent CreateMessageObject(string message, Vector2 position) {
             return new TextComponent(
-                _infoBoxUiObject,
+                _infoBoxGroup,
                 position,
                 new Vector2(InfoBoxWidth, MessageHeight),
                 message,

--- a/HKMP/UI/PingUI.cs
+++ b/HKMP/UI/PingUI.cs
@@ -20,35 +20,35 @@ namespace HKMP.UI {
         // The size (width and height) of the icon displayed in front of the text
         private const float IconSize = 20f;
 
-        private readonly GameObject _pingUiObject;
+        private readonly UIGroup _pingUiGroup;
         private readonly ModSettings _modSettings;
         private readonly NetClient _netClient;
 
         public PingUI(
-            GameObject pingUiObject,
+            UIGroup pingUiGroup,
             ModSettings modSettings,
             ClientManager clientManager, 
             NetClient netClient
         ) {
-            _pingUiObject = pingUiObject;
+            _pingUiGroup = pingUiGroup;
             _modSettings = modSettings;
             _netClient = netClient;
             
             // Since we are initially not connected, we disable the object by default
-            pingUiObject.SetActive(false);
+            pingUiGroup.SetActive(false);
 
             new ImageComponent(
-                pingUiObject,
+                pingUiGroup,
                 new Vector2(
-                    ScreenBorderMargin, Screen.height - ScreenBorderMargin),
+                    ScreenBorderMargin, 1080f - ScreenBorderMargin),
                 new Vector2(IconSize, IconSize),
                 TextureManager.NetworkIcon
             );
 
             var pingTextComponent = new TextComponent(
-                pingUiObject,
+                pingUiGroup,
                 new Vector2(
-                    ScreenBorderMargin + IconSize + IconTextMargin, Screen.height - ScreenBorderMargin - 1),
+                    ScreenBorderMargin + IconSize + IconTextMargin, 1080f - ScreenBorderMargin - 1),
                 new Vector2(TextWidth, TextHeight),
                 "",
                 FontManager.UIFontRegular,
@@ -75,7 +75,7 @@ namespace HKMP.UI {
         }
 
         public void SetEnabled(bool enabled) {
-            _pingUiObject.SetActive(enabled && _netClient.IsConnected && _modSettings.DisplayPing);
+            _pingUiGroup.SetActive(enabled && _netClient.IsConnected && _modSettings.DisplayPing);
         }
         
     }

--- a/HKMP/UI/ServerSettingsUI.cs
+++ b/HKMP/UI/ServerSettingsUI.cs
@@ -11,8 +11,8 @@ namespace HKMP.UI {
         private readonly ModSettings _modSettings;
         private readonly ServerManager _serverManager;
         
-        private readonly GameObject _settingsUiObject;
-        private readonly GameObject _connectUiObject;
+        private readonly UIGroup _settingsGroup;
+        private readonly UIGroup _connectGroup;
 
         private SettingsEntry[] _settingsEntries;
 
@@ -22,25 +22,25 @@ namespace HKMP.UI {
             Game.Settings.GameSettings gameSettings, 
             ModSettings modSettings, 
             ServerManager serverManager, 
-            GameObject settingsUiObject, 
-            GameObject connectUiObject
+            UIGroup settingsGroup, 
+            UIGroup connectGroup
         ) {
             _gameSettings = gameSettings;
             _modSettings = modSettings;
             _serverManager = serverManager;
-            _settingsUiObject = settingsUiObject;
-            _connectUiObject = connectUiObject;
+            _settingsGroup = settingsGroup;
+            _connectGroup = connectGroup;
             
             CreateSettings();
             CreateSettingsUI();
         }
 
         private void CreateSettingsUI() {
-            _settingsUiObject.SetActive(false);
+            _settingsGroup.SetActive(false);
 
             const float pageYLimit = 250;
             
-            var x = Screen.width - 210.0f;
+            var x = 1920f - 210.0f;
             var y = pageYLimit;
 
             const int boolMargin = 75;
@@ -49,21 +49,20 @@ namespace HKMP.UI {
             const int doubleIntMargin = 125;
 
             var settingsUIEntries = new List<SettingsUIEntry>();
-            var pages = new Dictionary<int, GameObject>();
+            var pages = new Dictionary<int, UIGroup>();
 
             var currentPage = 0;
-            GameObject currentPageObject = null;
+            UIGroup currentPageGroup = null;
 
             foreach (var settingsEntry in _settingsEntries) {
                 if (y <= pageYLimit) {
                     currentPage++;
-                    currentPageObject = new GameObject($"Settings Page {currentPage}");
-                    currentPageObject.SetActive(currentPage == 1);
-                    currentPageObject.transform.SetParent(_settingsUiObject.transform);
-                    
-                    pages.Add(currentPage, currentPageObject);
 
-                    y = Screen.height - 75.0f;
+                    currentPageGroup = new UIGroup(currentPage == 1, _settingsGroup);
+                    
+                    pages.Add(currentPage, currentPageGroup);
+
+                    y = 1080f - 75.0f;
                 }
                 
                 var nameChars = settingsEntry.Name.ToCharArray();
@@ -78,7 +77,7 @@ namespace HKMP.UI {
                 var doubleLine = nameWidth >= SettingsUIEntry.TextWidth;
 
                 settingsUIEntries.Add(new SettingsUIEntry(
-                    currentPageObject,
+                    currentPageGroup,
                     new Vector2(x, y),
                     settingsEntry.Name,
                     settingsEntry.Type,
@@ -98,7 +97,7 @@ namespace HKMP.UI {
             y = pageYLimit - 80;
 
             var nextPageButton = new ButtonComponent(
-                _settingsUiObject,
+                _settingsGroup,
                 new Vector2(x, y),
                 "Next page"
             );
@@ -118,7 +117,7 @@ namespace HKMP.UI {
             y -= 40;
             
             var previousPageButton = new ButtonComponent(
-                _settingsUiObject,
+                _settingsGroup,
                 new Vector2(x, y),
                 "Previous page"
             );
@@ -138,7 +137,7 @@ namespace HKMP.UI {
             y -= 40;
 
             var saveSettingsButton = new ButtonComponent(
-                _settingsUiObject,
+                _settingsGroup,
                 new Vector2(x, y),
                 "Save settings"
             );
@@ -157,12 +156,12 @@ namespace HKMP.UI {
             y -= 40;
 
             new ButtonComponent(
-                _settingsUiObject,
+                _settingsGroup,
                 new Vector2(x, y),
                 "Back"
             ).SetOnPress(() => {
-                _settingsUiObject.SetActive(false);
-                _connectUiObject.SetActive(true);
+                _settingsGroup.SetActive(false);
+                _connectGroup.SetActive(true);
             });
         }
 

--- a/HKMP/UI/SettingsUIEntry.cs
+++ b/HKMP/UI/SettingsUIEntry.cs
@@ -19,7 +19,7 @@ namespace HKMP.UI {
         private readonly bool _doubleLine;
 
         public SettingsUIEntry(
-            GameObject parent, 
+            UIGroup uiGroup, 
             Vector2 position, 
             string name, 
             Type type, 
@@ -35,7 +35,7 @@ namespace HKMP.UI {
             _doubleLine = doubleLine;
 
             new TextComponent(
-                parent,
+                uiGroup,
                 position + new Vector2(50, doubleLine ? -20 : 0),
                 new Vector2(TextWidth, doubleLine ? 40 : 30),
                 name,
@@ -46,7 +46,7 @@ namespace HKMP.UI {
 
             if (type == typeof(byte)) {
                 _input = new InputComponent(
-                    parent,
+                    uiGroup,
                     position - new Vector2(0, 35 + (doubleLine ? 25 : 0)),
                     new Vector2(InputWidth, InputHeight),
                     currentValue.ToString(),
@@ -59,7 +59,7 @@ namespace HKMP.UI {
                 // TODO: make the constructor parameter "autoApply" work with integer input
 
                 new TextComponent(
-                    parent,
+                    uiGroup,
                     position - new Vector2(0, 60 + (doubleLine ? 25 : 0)),
                     new Vector2(InputWidth, 20),
                     "default value: " + defaultValue,
@@ -69,7 +69,7 @@ namespace HKMP.UI {
             } else if (type == typeof(bool)) {
                 if (currentValue is bool currentChecked) {
                     _checkbox = new CheckboxComponent(
-                        parent,
+                        uiGroup,
                         position - new Vector2(90, 30 + (doubleLine ? 25 : 0)),
                         new Vector2(20, 20),
                         currentChecked,
@@ -85,7 +85,7 @@ namespace HKMP.UI {
                 }
 
                 new TextComponent(
-                    parent,
+                    uiGroup,
                     position - new Vector2(-40, 30 + (doubleLine ? 25 : 0)),
                     new Vector2(InputWidth, 20),
                     "default value: " + defaultValue,

--- a/HKMP/UI/UIGroup.cs
+++ b/HKMP/UI/UIGroup.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+
+namespace HKMP.UI {
+    public class UIGroup {
+
+        private readonly List<UIGroup> _children;
+        private readonly List<Component.IComponent> _components;
+
+        private UIGroup _parent;
+        private bool _activeSelf;
+
+        public UIGroup(bool activeSelf = true, UIGroup parent = null) {
+            _children = new List<UIGroup>();
+            _components = new List<Component.IComponent>();
+            
+            _activeSelf = activeSelf;
+
+            SetParent(parent);
+        }
+
+        /**
+         * Returns whether the parent hierarchy is active
+         */
+        private bool IsHierarchyActive() {
+            return _activeSelf && (_parent == null || _parent.IsHierarchyActive());
+        }
+
+        /**
+         * If the parent or its hierarchy changes, this method is called
+         */
+        private void OnParentUpdate(bool hierarchyActive) {
+            // Check whether we need to activate or deactivate our own components
+            var newActive = hierarchyActive && _activeSelf;
+
+            SetComponentsActive(newActive);
+
+            // Propagate this to all children
+            foreach (var child in _children) {
+                child.OnParentUpdate(newActive);
+            }
+        }
+        
+        private void SetComponentsActive(bool active) {
+            foreach (var component in _components) {
+                component.SetGroupActive(active);
+            }
+        }
+
+        public void SetParent(UIGroup parent) {
+            _parent = parent;
+
+            parent?._children.Add(this);
+            
+            // The parent changed, so we need to check whether our components or children should
+            // still be activated
+            OnParentUpdate(IsHierarchyActive());
+        }
+
+        public void AddComponent(Component.IComponent component) {
+            _components.Add(component);
+
+            component.SetGroupActive(_activeSelf && IsHierarchyActive());
+        }
+
+        public void SetActive(bool active) {
+            _activeSelf = active;
+
+            // Check whether the parent hierarchy is active and call the update
+            OnParentUpdate(IsHierarchyActive());
+        }
+
+        public bool IsActive() {
+            return _activeSelf && IsHierarchyActive();
+        }
+    }
+}

--- a/HKMP/UI/UIManager.cs
+++ b/HKMP/UI/UIManager.cs
@@ -12,6 +12,8 @@ using ModSettings = HKMP.Game.Settings.ModSettings;
 
 namespace HKMP.UI {
     public class UIManager {
+        public static GameObject UiGameObject;
+        
         public static InfoBoxUI InfoBox;
 
         private readonly ModSettings _modSettings;
@@ -34,7 +36,7 @@ namespace HKMP.UI {
             _modSettings = modSettings;
 
             // First we create a gameObject that will hold all other objects of the UI
-            var topUiObject = new GameObject();
+            UiGameObject = new GameObject();
 
             // Create event system object
             var eventSystemObj = new GameObject("EventSystem");
@@ -48,53 +50,45 @@ namespace HKMP.UI {
             Object.DontDestroyOnLoad(eventSystemObj);
 
             // Make sure that our UI is an overlay on the screen
-            topUiObject.AddComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
+            UiGameObject.AddComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
 
             // Also scale the UI with the screen size
-            var canvasScaler = topUiObject.AddComponent<CanvasScaler>();
+            var canvasScaler = UiGameObject.AddComponent<CanvasScaler>();
             canvasScaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
-            canvasScaler.referenceResolution = new Vector2(Screen.width, Screen.height);
+            canvasScaler.referenceResolution = new Vector2(1920f, 1080f);
 
-            topUiObject.AddComponent<GraphicRaycaster>();
+            UiGameObject.AddComponent<GraphicRaycaster>();
 
-            Object.DontDestroyOnLoad(topUiObject);
+            Object.DontDestroyOnLoad(UiGameObject);
 
-            PrecacheText(topUiObject);
+            PrecacheText();
 
-            var pauseMenuUiObject = new GameObject();
-            pauseMenuUiObject.transform.SetParent(topUiObject.transform);
-            pauseMenuUiObject.SetActive(false);
+            var pauseMenuGroup = new UIGroup(false);
 
-            var connectUiObject = new GameObject();
-            connectUiObject.transform.SetParent(pauseMenuUiObject.transform);
+            var connectGroup = new UIGroup(parent: pauseMenuGroup);
 
-            var clientSettingsUiObject = new GameObject();
-            clientSettingsUiObject.transform.SetParent(pauseMenuUiObject.transform);
-            var serverSettingsUiObject = new GameObject();
-            serverSettingsUiObject.transform.SetParent(pauseMenuUiObject.transform);
+            var clientSettingsGroup = new UIGroup(parent: pauseMenuGroup);
+            var serverSettingsGroup = new UIGroup(parent: pauseMenuGroup);
 
             new ConnectUI(
                 modSettings,
                 clientManager,
                 serverManager,
-                connectUiObject,
-                clientSettingsUiObject,
-                serverSettingsUiObject
+                connectGroup,
+                clientSettingsGroup,
+                serverSettingsGroup
             );
+            
+            var inGameGroup = new UIGroup();
+            
+            var infoBoxGroup = new UIGroup(parent: inGameGroup);
 
-            var inGameUiObject = new GameObject();
-            inGameUiObject.transform.SetParent(topUiObject.transform);
+            InfoBox = new InfoBoxUI(infoBoxGroup);
 
-            var infoBoxUiObject = new GameObject();
-            infoBoxUiObject.transform.SetParent(inGameUiObject.transform);
-
-            InfoBox = new InfoBoxUI(infoBoxUiObject);
-
-            var pingUiObject = new GameObject();
-            pingUiObject.transform.SetParent(inGameUiObject.transform);
+            var pingGroup = new UIGroup(parent: inGameGroup);
 
             var pingUi = new PingUI(
-                pingUiObject,
+                pingGroup,
                 modSettings,
                 clientManager,
                 netClient
@@ -104,17 +98,17 @@ namespace HKMP.UI {
                 modSettings,
                 clientGameSettings,
                 clientManager,
-                clientSettingsUiObject,
-                connectUiObject,
+                clientSettingsGroup,
+                connectGroup,
                 pingUi
             );
-
+            
             new ServerSettingsUI(
                 serverGameSettings,
                 modSettings,
                 serverManager,
-                serverSettingsUiObject,
-                connectUiObject
+                serverSettingsGroup,
+                connectGroup
             );
 
             // Register callbacks to make sure the UI is hidden and shown at correct times
@@ -126,21 +120,21 @@ namespace HKMP.UI {
                 if (!SceneUtil.IsNonGameplayScene(SceneUtil.GetCurrentSceneName())) {
                     _canShowPauseUi = true;
 
-                    pauseMenuUiObject.SetActive(!_isPauseUiHiddenByKeybind);
+                    pauseMenuGroup.SetActive(!_isPauseUiHiddenByKeybind);
                 }
 
-                inGameUiObject.SetActive(false);
+                inGameGroup.SetActive(false);
             };
             On.HeroController.UnPause += (orig, self) => {
                 // Execute original method
                 orig(self);
-                pauseMenuUiObject.SetActive(false);
+                pauseMenuGroup.SetActive(false);
 
                 _canShowPauseUi = false;
 
                 // Only show info box UI in gameplay scenes
                 if (!SceneUtil.IsNonGameplayScene(SceneUtil.GetCurrentSceneName())) {
-                    inGameUiObject.SetActive(true);
+                    inGameGroup.SetActive(true);
                 }
             };
             UnityEngine.SceneManagement.SceneManager.activeSceneChanged += (oldScene, newScene) => {
@@ -149,32 +143,32 @@ namespace HKMP.UI {
 
                     _canShowPauseUi = false;
 
-                    pauseMenuUiObject.SetActive(false);
-                    inGameUiObject.SetActive(false);
+                    pauseMenuGroup.SetActive(false);
+                    inGameGroup.SetActive(false);
                 } else {
                     eventSystem.enabled = true;
 
-                    inGameUiObject.SetActive(true);
+                    inGameGroup.SetActive(true);
                 }
             };
 
             // The game is automatically unpaused when the knight dies, so we need
             // to disable the UI menu manually
             // TODO: this still gives issues, since it displays the cursor while we are supposed to be unpaused
-            ModHooks.Instance.AfterPlayerDeadHook += () => { pauseMenuUiObject.SetActive(false); };
-
-            MonoBehaviourUtil.Instance.OnUpdateEvent += () => { CheckKeybinds(pauseMenuUiObject); };
+            ModHooks.Instance.AfterPlayerDeadHook += () => { pauseMenuGroup.SetActive(false); };
+            
+            MonoBehaviourUtil.Instance.OnUpdateEvent += () => { CheckKeybinds(pauseMenuGroup); };
         }
 
         // TODO: find a more elegant solution to this
-        private void PrecacheText(GameObject parent) {
+        private void PrecacheText() {
             // Create off-screen text components containing a set of characters we need so they are prerendered,
             // otherwise calculating characterInfo from Unity fails
             var fontSizes = new[] {13, 18};
 
             foreach (var fontSize in fontSizes) {
                 new TextComponent(
-                    parent,
+                    null,
                     new Vector2(-10000, 0),
                     new Vector2(100, 100),
                     StringUtil.AllUsableCharacters,
@@ -182,7 +176,7 @@ namespace HKMP.UI {
                     fontSize
                 );
                 new TextComponent(
-                    parent,
+                    null,
                     new Vector2(-10000, 0),
                     new Vector2(100, 100),
                     StringUtil.AllUsableCharacters,
@@ -192,7 +186,7 @@ namespace HKMP.UI {
             }
         }
 
-        private void CheckKeybinds(GameObject pauseMenuUiObject) {
+        private void CheckKeybinds(UIGroup pauseMenuGroup) {
             if (Input.GetKeyDown((KeyCode) _modSettings.HideUiKey)) {
                 _isPauseUiHiddenByKeybind = !_isPauseUiHiddenByKeybind;
 
@@ -200,11 +194,11 @@ namespace HKMP.UI {
 
                 if (_isPauseUiHiddenByKeybind) {
                     // If we toggled the UI off, we hide it if it was shown
-                    pauseMenuUiObject.SetActive(false);
+                    pauseMenuGroup.SetActive(false);
                 } else if (_canShowPauseUi) {
                     // If we toggled the UI on again and we are in a pause menu
                     // where we can show the UI, we enabled it
-                    pauseMenuUiObject.SetActive(true);
+                    pauseMenuGroup.SetActive(true);
                 }
             }
         }


### PR DESCRIPTION
Starting the game with a different resolution than 1920 by 1080 wouldn't scale the UI elements accordingly. This is now fixed by reworking how UI elements are handled. Moreover, the `GameObject` hierarchy that was in place before has been replaced by `UIGroup` classes that solely handle activation hierarchy of UI elements.