### PR TITLE
Fix animation updates being overwritten

### DIFF
--- a/HKMP/Game/Client/ClientManager.cs
+++ b/HKMP/Game/Client/ClientManager.cs
@@ -374,12 +374,14 @@ namespace Hkmp.Game.Client {
             }
 
             if (entityUpdate.UpdateTypes.Contains(EntityUpdateType.Animation)) {
-                _entityManager.UpdateEntityAnimation(
-                    (EntityType) entityUpdate.EntityType,
-                    entityUpdate.Id,
-                    entityUpdate.AnimationIndex,
-                    entityUpdate.AnimationInfo
-                );
+                foreach (var animation in entityUpdate.AnimationInfos) {
+                    _entityManager.UpdateEntityAnimation(
+                        (EntityType) entityUpdate.EntityType,
+                        entityUpdate.Id,
+                        animation.AnimationIndex,
+                        animation.AnimationInfo
+                    );
+                }
             }
 
             if (entityUpdate.UpdateTypes.Contains(EntityUpdateType.State)) {

--- a/HKMP/Networking/Client/ClientUpdateManager.cs
+++ b/HKMP/Networking/Client/ClientUpdateManager.cs
@@ -153,8 +153,13 @@ namespace Hkmp.Networking.Client {
                 var entityUpdate = FindOrCreateEntityUpdate(entityType, entityId);
 
                 entityUpdate.UpdateTypes.Add(EntityUpdateType.Animation);
-                entityUpdate.AnimationIndex = animationIndex;
-                entityUpdate.AnimationInfo = animationInfo;
+
+                var animation = new EntityAnimationInfo {
+                    AnimationIndex = animationIndex,
+                    AnimationInfo = animationInfo
+                };
+
+                entityUpdate.AnimationInfos.Add(animation);
             }
         }
 

--- a/HKMPShared/Networking/Packet/Data/EntityUpdate.cs
+++ b/HKMPShared/Networking/Packet/Data/EntityUpdate.cs
@@ -20,7 +20,7 @@ namespace Hkmp.Networking.Packet.Data {
 
         public bool Scale { get; set; }
 
-        public List<EntityAnimationInfo> AnimationInfos { get; set; }
+        public List<EntityAnimationInfo> AnimationInfos { get; }
 
         public byte State { get; set; }
 

--- a/HKMPShared/Networking/Packet/Data/EntityUpdate.cs
+++ b/HKMPShared/Networking/Packet/Data/EntityUpdate.cs
@@ -20,16 +20,13 @@ namespace Hkmp.Networking.Packet.Data {
 
         public bool Scale { get; set; }
 
-        public byte AnimationIndex { get; set; }
+        public List<EntityAnimationInfo> AnimationInfos { get; set; }
 
-        public byte[] AnimationInfo { get; set; }
-        
         public byte State { get; set; }
 
         public EntityUpdate() {
             UpdateTypes = new HashSet<EntityUpdateType>();
-
-            AnimationInfo = new byte[0];
+            AnimationInfos = new List<EntityAnimationInfo>();
         }
 
         public void WriteData(Packet packet) {
@@ -64,17 +61,28 @@ namespace Hkmp.Networking.Packet.Data {
             }
 
             if (UpdateTypes.Contains(EntityUpdateType.Animation)) {
-                packet.Write(AnimationIndex);
+                // First write the number of animations
+                // Maximum number of animations in one packet can be 255, this should be more than enough
+                var numAnimations = (byte) System.Math.Min(AnimationInfos.Count, byte.MaxValue);
 
-                if (AnimationInfo == null) {
-                    packet.Write(0);
-                } else {
-                    var animationInfoLength = (byte) System.Math.Min(byte.MaxValue, AnimationInfo.Length);
+                packet.Write(numAnimations);
 
-                    packet.Write(animationInfoLength);
+                foreach (var animation in AnimationInfos) {
+                    packet.Write(animation.AnimationIndex);
 
-                    for (var i = 0; i < animationInfoLength; i++) {
-                        packet.Write(AnimationInfo[i]);
+                    // Check whether there is info to write
+                    if (animation.AnimationInfo == null) {
+                        packet.Write(0);
+                    } else {
+                        // Write the length of the info
+                        var animationInfoLength = (byte) System.Math.Min(animation.AnimationInfo.Length, byte.MaxValue);
+
+                        packet.Write(animationInfoLength);
+
+                        // Write the info in the packet
+                        foreach (var animationInfo in animation.AnimationInfo) {
+                            packet.Write(animationInfo);
+                        }
                     }
                 }
             }
@@ -113,13 +121,24 @@ namespace Hkmp.Networking.Packet.Data {
             }
             
             if (UpdateTypes.Contains(EntityUpdateType.Animation)) {
-                AnimationIndex = packet.ReadByte();
+                // First read how many animations are in the packet
+                var numAnimations = packet.ReadByte();
 
-                var animationInfoLength = packet.ReadByte();
+                for (var i = 0; i < numAnimations; i++) {
+                    // Create new animation info
+                    var animation = new EntityAnimationInfo {
+                        AnimationIndex = packet.ReadByte()
+                    };
 
-                AnimationInfo = new byte[animationInfoLength];
-                for (var i = 0; i < animationInfoLength; i++) {
-                    AnimationInfo[i] = packet.ReadByte();
+                    // Read how many info bytes there are for this animation
+                    var animationInfoLength = packet.ReadByte();
+
+                    animation.AnimationInfo = new byte[animationInfoLength];
+                    for (var j = 0; j < animationInfoLength; j++) {
+                        animation.AnimationInfo[j] = packet.ReadByte();
+                    }
+
+                    AnimationInfos.Add(animation);
                 }
             }
 
@@ -134,5 +153,10 @@ namespace Hkmp.Networking.Packet.Data {
         Scale,
         Animation,
         State
+    }
+
+    public class EntityAnimationInfo {
+        public byte AnimationIndex { get; set; }
+        public byte[] AnimationInfo { get; set;  }
     }
 }

--- a/HKMPShared/Networking/ServerUpdateManager.cs
+++ b/HKMPShared/Networking/ServerUpdateManager.cs
@@ -235,8 +235,13 @@ namespace Hkmp.Networking {
                 var entityUpdate = FindOrCreateEntityUpdate(entityType, entityId);
 
                 entityUpdate.UpdateTypes.Add(EntityUpdateType.Animation);
-                entityUpdate.AnimationIndex = animationIndex;
-                entityUpdate.AnimationInfo = animationInfo;
+
+                var animation = new EntityAnimationInfo {
+                    AnimationIndex = animationIndex,
+                    AnimationInfo = animationInfo
+                };
+
+                entityUpdate.AnimationInfos.Add(animation);
             }
         }
 


### PR DESCRIPTION
As we discussed in the discord, this PR makes it so multiple entity animation updates can be send in one packet.