### PR TITLE
Add Explicit casts from Hkmp.Math.Vector to UnityEngine.Vector

### DIFF
--- a/HKMP/Math/Vector2.cs
+++ b/HKMP/Math/Vector2.cs
@@ -75,23 +75,23 @@ namespace Hkmp.Math {
         public static bool operator !=(Vector2 lhs, Vector2 rhs) {
             return !(lhs == rhs);
         }
-		
-		    /// <summary>
-			/// Cast from a UnityEngine.Vector2 to a Hkmp.Math.Vector2
-			/// </summary>
-			/// <param name="vector2">The UnityEngine.Vector2 to cast from</param>
-			/// <returns></returns>
-			public static explicit operator Vector2(UnityEngine.Vector2 vector2){
-				return new Vector2(vector2.x, vector2.y);
-			}
 
-			/// <summary>
-			/// Cast from Hkmp.Math.Vector2 to UnityEngine.Vector2
-			/// </summary>
-			/// <param name="vector2">The Hkmp.Math.Vector2 to cast from</param>
-			/// <returns></returns>
-			public static explicit operator UnityEngine.Vector2(Vector2 vector2){
-				return new UnityEngine.Vector2(vector2.X, vector2.X);
-			}
+        /// <summary>
+        /// Explicit conversion from a UnityEngine.Vector2 to a Hkmp.Math.Vector2.
+        /// </summary>
+        /// <param name="vector2">The UnityEngine.Vector2 to convert.</param>
+        /// <returns>The converted Hkmp.Math.Vector2.</returns>
+        public static explicit operator Vector2(UnityEngine.Vector2 vector2) {
+            return new Vector2(vector2.x, vector2.y);
+        }
+
+        /// <summary>
+        /// Explicit conversion from a Hkmp.Math.Vector2 to a UnityEngine.Vector2.
+        /// </summary>
+        /// <param name="vector2">The Hkmp.Math.Vector2 to convert.</param>
+        /// <returns>The converted UnityEngine.Vector2.</returns>
+        public static explicit operator UnityEngine.Vector2(Vector2 vector2) {
+            return new UnityEngine.Vector2(vector2.X, vector2.X);
+        }
     }
 }

--- a/HKMP/Math/Vector2.cs
+++ b/HKMP/Math/Vector2.cs
@@ -75,5 +75,23 @@ namespace Hkmp.Math {
         public static bool operator !=(Vector2 lhs, Vector2 rhs) {
             return !(lhs == rhs);
         }
+		
+		    /// <summary>
+			/// Cast from a UnityEngine.Vector2 to a Hkmp.Math.Vector2
+			/// </summary>
+			/// <param name="vector2">The UnityEngine.Vector2 to cast from</param>
+			/// <returns></returns>
+			public static explicit operator Vector2(UnityEngine.Vector2 vector2){
+				return new Vector2(vector2.x, vector2.y);
+			}
+
+			/// <summary>
+			/// Cast from Hkmp.Math.Vector2 to UnityEngine.Vector2
+			/// </summary>
+			/// <param name="vector2">The Hkmp.Math.Vector2 to cast from</param>
+			/// <returns></returns>
+			public static explicit operator UnityEngine.Vector2(Vector2 vector2){
+				return new UnityEngine.Vector2(vector2.X, vector2.X);
+			}
     }
 }

--- a/HKMP/Math/Vector3.cs
+++ b/HKMP/Math/Vector3.cs
@@ -29,19 +29,19 @@ namespace Hkmp.Math {
         }
 		
 		/// <summary>
-		/// Cast from a UnityEngine.Vector3 to a Hkmp.Math.Vector3
+		/// Explicit conversion from a UnityEngine.Vector3 to a Hkmp.Math.Vector3.
 		/// </summary>
-		/// <param name="vector3">The UnityEngine.Vector3 to cast from</param>
-		/// <returns></returns>
+		/// <param name="vector3">The UnityEngine.Vector3 to convert.</param>
+		/// <returns>The converted Hkmp.Math.Vector2.</returns>
 		public static explicit operator Vector3(UnityEngine.Vector3 vector3){
 			return new Vector3(vector3.x, vector3.y, vector3.z);
 		}
 
 		/// <summary>
-		/// Cast from Hkmp.Math.Vector3 to UnityEngine.Vector3
+		/// Explicit conversion from a Hkmp.Math.Vector3 to a UnityEngine.Vector3.
 		/// </summary>
-		/// <param name="vector3">The Hkmp.Math.Vector2 to cast from</param>
-		/// <returns></returns>
+		/// <param name="vector3">The Hkmp.Math.Vector3 to convert.</param>
+		/// <returns>The converted UnityEngine.Vector3.</returns>
 		public static explicit operator UnityEngine.Vector3(Vector3 vector3){
 			return new UnityEngine.Vector3(vector3.X, vector3.X, vector3.Z);
 		}

--- a/HKMP/Math/Vector3.cs
+++ b/HKMP/Math/Vector3.cs
@@ -27,5 +27,23 @@ namespace Hkmp.Math {
             Y = y;
             Z = z;
         }
+		
+		/// <summary>
+		/// Cast from a UnityEngine.Vector3 to a Hkmp.Math.Vector3
+		/// </summary>
+		/// <param name="vector3">The UnityEngine.Vector3 to cast from</param>
+		/// <returns></returns>
+		public static explicit operator Vector3(UnityEngine.Vector3 vector3){
+			return new Vector3(vector3.x, vector3.y, vector3.z);
+		}
+
+		/// <summary>
+		/// Cast from Hkmp.Math.Vector3 to UnityEngine.Vector3
+		/// </summary>
+		/// <param name="vector3">The Hkmp.Math.Vector2 to cast from</param>
+		/// <returns></returns>
+		public static explicit operator UnityEngine.Vector3(Vector3 vector3){
+			return new UnityEngine.Vector3(vector3.X, vector3.X, vector3.Z);
+		}
     }
 }

--- a/HKMP/Math/Vector3.cs
+++ b/HKMP/Math/Vector3.cs
@@ -32,7 +32,7 @@ namespace Hkmp.Math {
 		/// Explicit conversion from a UnityEngine.Vector3 to a Hkmp.Math.Vector3.
 		/// </summary>
 		/// <param name="vector3">The UnityEngine.Vector3 to convert.</param>
-		/// <returns>The converted Hkmp.Math.Vector2.</returns>
+		/// <returns>The converted Hkmp.Math.Vector3.</returns>
 		public static explicit operator Vector3(UnityEngine.Vector3 vector3){
 			return new Vector3(vector3.x, vector3.y, vector3.z);
 		}


### PR DESCRIPTION
Use case: Since addons can't use game code like UnityEngine.Vector2, the server needs to send and receive Hkmp.Math.Vector2.
Possible could make them implicit