### PR TITLE
Adding Disconnect Player functionality to IServerManager

### DIFF
--- a/HKMP/Api/Server/IServerManager.cs
+++ b/HKMP/Api/Server/IServerManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Hkmp.Networking.Packet.Data;
 using JetBrains.Annotations;
 
 namespace Hkmp.Api.Server {
@@ -54,12 +55,13 @@ namespace Hkmp.Api.Server {
         /// <exception cref="ArgumentException">Thrown if the message is null or the length of the message is
         /// greater than 255 or the message contains invalid characters.</exception>
         void BroadcastMessage(string message);
-        
+
         /// <summary>
-        /// Kick the player with the given ID. Specialization of DisconnectPlayer for API.
+        /// Disconnect the player with the given ID for the given reason.
         /// </summary>
         /// <param name="id">The ID of the player.</param>
-        void KickPlayer(ushort id);
+        /// <param name="reason">The reason for the disconnect.</param>
+        void DisconnectPlayer(ushort id, DisconnectReason reason);
 
         /// <summary>
         /// Event that is called when a player connects to the server.

--- a/HKMP/Api/Server/IServerManager.cs
+++ b/HKMP/Api/Server/IServerManager.cs
@@ -54,6 +54,12 @@ namespace Hkmp.Api.Server {
         /// <exception cref="ArgumentException">Thrown if the message is null or the length of the message is
         /// greater than 255 or the message contains invalid characters.</exception>
         void BroadcastMessage(string message);
+        
+        /// <summary>
+        /// Kick the player with the given ID. Specialization of DisconnectPlayer for API.
+        /// </summary>
+        /// <param name="id">The ID of the player.</param>
+        void KickPlayer(ushort id);
 
         /// <summary>
         /// Event that is called when a player connects to the server.

--- a/HKMP/Game/Command/Server/BanCommand.cs
+++ b/HKMP/Game/Command/Server/BanCommand.cs
@@ -176,7 +176,7 @@ namespace Hkmp.Game.Command.Server {
         /// Disconnect the player with the given player data.
         /// </summary>
         /// <param name="playerData">The player data for the player to disconnect.</param>
-        private void DisconnectPlayer(ServerPlayerData playerData) => _serverManager.DisconnectPlayer(
+        private void DisconnectPlayer(ServerPlayerData playerData) => _serverManager.InternalDisconnectPlayer(
             playerData.Id,
             DisconnectReason.Banned
         );

--- a/HKMP/Game/Command/Server/KickCommand.cs
+++ b/HKMP/Game/Command/Server/KickCommand.cs
@@ -74,7 +74,7 @@ namespace Hkmp.Game.Command.Server {
         /// </summary>
         /// <param name="player">The server player data instance for the player.</param>
         private void KickPlayer(IServerPlayer player) {
-            _serverManager.DisconnectPlayer(player.Id, DisconnectReason.Kicked);
+            _serverManager.InternalDisconnectPlayer(player.Id, DisconnectReason.Kicked);
         }
     }
 }

--- a/HKMP/Game/Server/ServerManager.cs
+++ b/HKMP/Game/Server/ServerManager.cs
@@ -541,6 +541,15 @@ namespace Hkmp.Game.Server {
         }
 
         /// <summary>
+        /// Kick the player with the given ID. Specialization of DisconnectPlayer for API.
+        /// </summary>
+        /// <param name="id">The ID of the player.</param>
+        public void KickPlayer(ushort id)
+        {
+            DisconnectPlayer(id, DisconnectReason.Kicked);
+        }
+
+        /// <summary>
         /// Disconnect the player with the given ID.
         /// </summary>
         /// <param name="id">The ID of the player.</param>

--- a/HKMP/Game/Server/ServerManager.cs
+++ b/HKMP/Game/Server/ServerManager.cs
@@ -530,27 +530,18 @@ namespace Hkmp.Game.Server {
         }
 
         /// <summary>
-        /// Disconnect the player with the given ID for the given reason.
+        /// Internal method for disconnecting a player with the given ID for the given reason.
         /// </summary>
         /// <param name="id">The ID of the player.</param>
         /// <param name="reason">The reason for the disconnect.</param>
-        public void DisconnectPlayer(ushort id, DisconnectReason reason) {
-            _netServer.GetUpdateManagerForClient(id).SetDisconnect(reason);
+        public void InternalDisconnectPlayer(ushort id, DisconnectReason reason) {
+            _netServer.GetUpdateManagerForClient(id)?.SetDisconnect(reason);
 
             ProcessPlayerDisconnect(id);
         }
 
         /// <summary>
-        /// Kick the player with the given ID. Specialization of DisconnectPlayer for API.
-        /// </summary>
-        /// <param name="id">The ID of the player.</param>
-        public void KickPlayer(ushort id)
-        {
-            DisconnectPlayer(id, DisconnectReason.Kicked);
-        }
-
-        /// <summary>
-        /// Disconnect the player with the given ID.
+        /// Process a disconnect for the player with the given ID.
         /// </summary>
         /// <param name="id">The ID of the player.</param>
         /// <param name="timeout">Whether this player timed out or disconnected normally.</param>
@@ -940,6 +931,15 @@ namespace Hkmp.Game.Server {
                 var updateManager = _netServer.GetUpdateManagerForClient(player.Id);
                 updateManager?.AddChatMessage(message);
             }
+        }
+        
+        /// <inheritdoc />
+        public void DisconnectPlayer(ushort id, DisconnectReason reason) {
+            if (!_playerData.TryGetValue(id, out _)) {
+                throw new ArgumentException("There is no player connected with the given ID");
+            }
+
+            InternalDisconnectPlayer(id, reason);
         }
 
         #endregion

--- a/HKMP/Networking/Packet/Data/ServerClientDisconnect.cs
+++ b/HKMP/Networking/Packet/Data/ServerClientDisconnect.cs
@@ -29,7 +29,7 @@ namespace Hkmp.Networking.Packet.Data {
     /// <summary>
     /// The reason for the disconnect from the server.
     /// </summary>
-    internal enum DisconnectReason {
+    public enum DisconnectReason {
         /// <summary>
         /// When the server is shut down and clients need to properly disconnected.
         /// </summary>


### PR DESCRIPTION
Needed the ability to programmatically kick a player for an addon I'm implementing and couldn't find it. Saw Kick Player was recently added as a command and the functionality already lived on the ServerManager so just raised it to the IServerManager.

I went the route of specializing DisconnectPlayer to KickPlayer in order not to expose the DisconnectReason enum as a part of the public API. As I'm new to the codebase I'm unsure if that tracks with the current philosophy and would love feedback on what the direction of the API looks like. I totally get if we'd prefer to expose the enum and let it be a generic DisconnectPlayer call, just didn't feel comfortable being the one making that call without checking.