### PR TITLE
Add docker standalone server info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ The latest executable of the server can be found on the [releases page](https://
 For Linux and Mac, the server can be run with [Mono](https://www.mono-project.com) installed.
 After installing Mono, the same executable can be run using `mono HKMPServer.exe <port>`.
 Currently, the only command-line argument is the port that the server should be hosted on.
-- For Docker :two_hearts: fans prepared image on [DockerHub](https://hub.docker.com/repository/docker/maximalmax90/hkmpserver)
+
+Alternatively, a Docker image is available on [DockerHub](https://hub.docker.com/repository/docker/maximalmax90/hkmpserver) (courtesy of [maximalmax90](https://github.com/maximalmax90)).
 
 The server will read/create a settings file called `gamesettings.json`, which can be changed to alter the default startup settings of the server.
 Alternatively, settings can be changed by running the settings command on the command line.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The latest executable of the server can be found on the [releases page](https://
 For Linux and Mac, the server can be run with [Mono](https://www.mono-project.com) installed.
 After installing Mono, the same executable can be run using `mono HKMPServer.exe <port>`.
 Currently, the only command-line argument is the port that the server should be hosted on.
+- For Docker :two_hearts: fans prepared image on [DockerHub](https://hub.docker.com/repository/docker/maximalmax90/hkmpserver)
 
 The server will read/create a settings file called `gamesettings.json`, which can be changed to alter the default startup settings of the server.
 Alternatively, settings can be changed by running the settings command on the command line.


### PR DESCRIPTION
Is a link enough or is it better to describe the process separately, as in my repository?