### PR TITLE
Get first action by type where possible

### DIFF
--- a/HKMP/Animation/AnimationEffect.cs
+++ b/HKMP/Animation/AnimationEffect.cs
@@ -1,4 +1,4 @@
-﻿using Hkmp.Util;
+using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
 
@@ -34,11 +34,11 @@ namespace Hkmp.Animation {
                 return;
             }
 
-            var takeDamage = damageFsm.GetAction<TakeDamage>("Send Event", 8);
+            var takeDamage = damageFsm.GetFirstAction<TakeDamage>("Send Event");
             takeDamage.AttackType.Value = (int) AttackTypes.Generic;
-            takeDamage = damageFsm.GetAction<TakeDamage>("Parent", 6);
+            takeDamage = damageFsm.GetFirstAction<TakeDamage>("Parent");
             takeDamage.AttackType.Value = (int) AttackTypes.Generic;
-            takeDamage = damageFsm.GetAction<TakeDamage>("Grandparent", 6);
+            takeDamage = damageFsm.GetFirstAction<TakeDamage>("Grandparent");
             takeDamage.AttackType.Value = (int) AttackTypes.Generic;
         }
     }

--- a/HKMP/Animation/AnimationManager.cs
+++ b/HKMP/Animation/AnimationManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -943,7 +943,7 @@ namespace Hkmp.Animation {
                 .LocateMyFSM("Hero Death Anim");
 
             // Get the nail fling object from the Blow state
-            var nailObject = heroDeathAnimFsm.GetAction<FlingObjectsFromGlobalPool>("Blow", 0);
+            var nailObject = heroDeathAnimFsm.GetFirstAction<FlingObjectsFromGlobalPool>("Blow");
 
             // Spawn it relative to the player
             var nailGameObject = nailObject.gameObject.Value.Spawn(
@@ -979,7 +979,7 @@ namespace Hkmp.Animation {
             }
 
             // Obtain a head object from the either Head states and instantiate it
-            var headObject = heroDeathAnimFsm.GetAction<CreateObject>(stateName, 0);
+            var headObject = heroDeathAnimFsm.GetFirstAction<CreateObject>(stateName);
             var headGameObject = Object.Instantiate(
                 headObject.gameObject.Value,
                 playerObject.transform.position + new Vector3(facingRight ? 0.2f : -0.2f, -0.02f, -0.01f),
@@ -1049,7 +1049,7 @@ namespace Hkmp.Animation {
         /// </summary>
         private void SetDescendingDarkLandEffectDelay() {
             var spellControl = HeroController.instance.spellControl;
-            var waitAction = spellControl.GetAction<Wait>("Q2 Land", 14);
+            var waitAction = spellControl.GetFirstAction<Wait>("Q2 Land");
             waitAction.time.Value = 0.4f;
         }
 

--- a/HKMP/Animation/Effects/CrystalDash.cs
+++ b/HKMP/Animation/Effects/CrystalDash.cs
@@ -1,4 +1,4 @@
-﻿using Hkmp.Util;
+using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
 using Random = System.Random;
@@ -81,12 +81,12 @@ namespace Hkmp.Animation.Effects {
                 superDashAudioObject.GetComponent<AudioSource>().clip = dashAudioSource.clip;
             }
 
-            var dashBurstAudioPlay = superDashFsm.GetAction<AudioPlay>("Dash Start", 1);
+            var dashBurstAudioPlay = superDashFsm.GetFirstAction<AudioPlay>("Dash Start");
 
             superDashAudioObject.GetComponent<AudioSource>()
                 .PlayOneShot((AudioClip) dashBurstAudioPlay.oneShotClip.Value);
 
-            var crystalAudioPlayRandom = superDashFsm.GetAction<AudioPlayRandom>("Dash Start", 3);
+            var crystalAudioPlayRandom = superDashFsm.GetFirstAction<AudioPlayRandom>("Dash Start");
 
             var randomIndex = new Random().Next(2);
 
@@ -96,7 +96,7 @@ namespace Hkmp.Animation.Effects {
             // Play the audio source
             superDashAudioObject.GetComponent<AudioSource>().Play();
 
-            var particleEmitAction = superDashFsm.GetAction<PlayParticleEmitter>("G Left", 0);
+            var particleEmitAction = superDashFsm.GetFirstAction<PlayParticleEmitter>("G Left");
             var particleEmitter = Object.Instantiate(
                 particleEmitAction.gameObject.GameObject.Value,
                 playerEffects.transform

--- a/HKMP/Animation/Effects/CrystalDashAirCancel.cs
+++ b/HKMP/Animation/Effects/CrystalDashAirCancel.cs
@@ -1,4 +1,4 @@
-﻿using Hkmp.Util;
+using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
 
@@ -22,7 +22,7 @@ namespace Hkmp.Animation.Effects {
 
             var superDashFsm = HeroController.instance.gameObject.LocateMyFSM("Superdash");
 
-            var airCancelAction = superDashFsm.GetAction<AudioPlay>("Air Cancel", 0);
+            var airCancelAction = superDashFsm.GetFirstAction<AudioPlay>("Air Cancel");
 
             audioSourceObject.GetComponent<AudioSource>().PlayOneShot((AudioClip) airCancelAction.oneShotClip.Value);
 

--- a/HKMP/Animation/Effects/CrystalDashChargeBase.cs
+++ b/HKMP/Animation/Effects/CrystalDashChargeBase.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
@@ -42,7 +42,7 @@ namespace Hkmp.Animation.Effects {
             var chargeAudioObject = playerObject.FindGameObjectInChildren("Superdash Charge Audio");
             if (chargeAudioObject == null) {
                 // There is not object yet, so we create one by finding the clip in the FSM
-                var chargeAudioPlay = superDashFsm.GetAction<AudioPlay>("Ground Charge", 3);
+                var chargeAudioPlay = superDashFsm.GetFirstAction<AudioPlay>("Ground Charge");
 
                 var chargeAudioSource = chargeAudioPlay.gameObject.GameObject.Value.GetComponent<AudioSource>();
 
@@ -80,7 +80,7 @@ namespace Hkmp.Animation.Effects {
             yield return new WaitForSeconds(0.8f);
 
             // Find the bling effect in the FSM and instantiate it
-            var blingEffectObject = superDashFsm.GetAction<ActivateGameObject>("Ground Charged", 4);
+            var blingEffectObject = superDashFsm.GetFirstAction<ActivateGameObject>("Ground Charged");
             var blingEffect = Object.Instantiate(
                 blingEffectObject.gameObject.GameObject.Value,
                 playerEffects.transform

--- a/HKMP/Animation/Effects/CrystalDashHitWall.cs
+++ b/HKMP/Animation/Effects/CrystalDashHitWall.cs
@@ -1,4 +1,4 @@
-﻿using Hkmp.Util;
+using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
 
@@ -31,7 +31,7 @@ namespace Hkmp.Animation.Effects {
 
             var superDashFsm = HeroController.instance.gameObject.LocateMyFSM("Superdash");
 
-            var wallHitAction = superDashFsm.GetAction<AudioPlay>("Hit Wall", 4);
+            var wallHitAction = superDashFsm.GetFirstAction<AudioPlay>("Hit Wall");
 
             audioSourceObject.GetComponent<AudioSource>().PlayOneShot((AudioClip) wallHitAction.oneShotClip.Value);
 

--- a/HKMP/Animation/Effects/CycloneSlash.cs
+++ b/HKMP/Animation/Effects/CycloneSlash.cs
@@ -1,4 +1,4 @@
-﻿using Hkmp.Util;
+using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
 
@@ -16,7 +16,7 @@ namespace Hkmp.Animation.Effects {
             var nailArts = HeroController.instance.gameObject.LocateMyFSM("Nail Arts");
 
             // Obtain the AudioSource from the AudioPlayerOneShotSingle action in the nail arts FSM
-            var audioAction = nailArts.GetAction<AudioPlayerOneShotSingle>("Play Audio", 0);
+            var audioAction = nailArts.GetFirstAction<AudioPlayerOneShotSingle>("Play Audio");
             var audioPlayerObj = audioAction.audioPlayer.Value;
             var audioPlayer = audioPlayerObj.Spawn(playerObject.transform);
             var audioSource = audioPlayer.GetComponent<AudioSource>();

--- a/HKMP/Animation/Effects/DashBase.cs
+++ b/HKMP/Animation/Effects/DashBase.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
@@ -203,7 +203,7 @@ namespace Hkmp.Animation.Effects {
             var rechargeFsm = shadowRechargePrefab.LocateMyFSM("Recharge Effect");
 
             // Obtain the recharge audio clip
-            var audioPlayAction = rechargeFsm.GetAction<AudioPlay>("Burst", 0);
+            var audioPlayAction = rechargeFsm.GetFirstAction<AudioPlay>("Burst");
             var rechargeAudioClip = (AudioClip) audioPlayAction.oneShotClip.Value;
 
             // Get a new audio source and play the clip

--- a/HKMP/Animation/Effects/DashSlash.cs
+++ b/HKMP/Animation/Effects/DashSlash.cs
@@ -1,4 +1,4 @@
-﻿using Hkmp.Util;
+using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
 
@@ -20,7 +20,7 @@ namespace Hkmp.Animation.Effects {
             var audioSource = audioObject.GetComponent<AudioSource>();
 
             // Get the audio clip of the Great Slash
-            var dashSlashClip = (AudioClip) nailArts.GetAction<AudioPlay>("Dash Slash", 1).oneShotClip.Value;
+            var dashSlashClip = (AudioClip) nailArts.GetFirstAction<AudioPlay>("Dash Slash").oneShotClip.Value;
             audioSource.PlayOneShot(dashSlashClip);
 
             Object.Destroy(audioObject, dashSlashClip.length);

--- a/HKMP/Animation/Effects/DescendingDarkLand.cs
+++ b/HKMP/Animation/Effects/DescendingDarkLand.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
@@ -32,7 +32,7 @@ namespace Hkmp.Animation.Effects {
             var audioSource = audioObject.GetComponent<AudioSource>();
 
             // Find the land clip and play it
-            var q2LandClip = (AudioClip) spellControl.GetAction<AudioPlay>("Q2 Land", 1).oneShotClip.Value;
+            var q2LandClip = (AudioClip) spellControl.GetFirstAction<AudioPlay>("Q2 Land").oneShotClip.Value;
             audioSource.PlayOneShot(q2LandClip);
 
             // Destroy the audio object after the clip is done

--- a/HKMP/Animation/Effects/DesolateDiveLand.cs
+++ b/HKMP/Animation/Effects/DesolateDiveLand.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
@@ -32,7 +32,7 @@ namespace Hkmp.Animation.Effects {
             var audioSource = audioObject.GetComponent<AudioSource>();
 
             // Find the land clip and play it
-            var qLandClip = (AudioClip) spellControl.GetAction<AudioPlay>("Quake1 Land", 1).oneShotClip.Value;
+            var qLandClip = (AudioClip) spellControl.GetFirstAction<AudioPlay>("Quake1 Land").oneShotClip.Value;
             audioSource.PlayOneShot(qLandClip);
 
             // Destroy the audio object after the clip is done

--- a/HKMP/Animation/Effects/DiveAntic.cs
+++ b/HKMP/Animation/Effects/DiveAntic.cs
@@ -1,4 +1,4 @@
-﻿using Hkmp.Util;
+using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
 
@@ -13,7 +13,7 @@ namespace Hkmp.Animation.Effects {
             var localSpellControl = HeroController.instance.spellControl;
 
             // Get the AudioPlay action from the Quake Antic state
-            var quakeAnticAudioPlay = localSpellControl.GetAction<AudioPlay>("Quake Antic", 0);
+            var quakeAnticAudioPlay = localSpellControl.GetFirstAction<AudioPlay>("Quake Antic");
 
             var audioObject = AudioUtil.GetAudioSourceObject(playerObject);
             var audioSource = audioObject.GetComponent<AudioSource>();

--- a/HKMP/Animation/Effects/DungTrail.cs
+++ b/HKMP/Animation/Effects/DungTrail.cs
@@ -1,4 +1,4 @@
-﻿using Hkmp.Util;
+using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
 
@@ -21,7 +21,7 @@ namespace Hkmp.Animation.Effects {
 
             var dungControlFsm = dungObject.LocateMyFSM("Control");
 
-            var spawnObjectAction = dungControlFsm.GetAction<SpawnObjectFromGlobalPoolOverTime>("Equipped", 0);
+            var spawnObjectAction = dungControlFsm.GetFirstAction<SpawnObjectFromGlobalPoolOverTime>("Equipped");
 
             // Spawn the dung trail object, which will despawn itself
             spawnObjectAction.gameObject.Value.Spawn(
@@ -35,7 +35,7 @@ namespace Hkmp.Animation.Effects {
                 return;
             }
 
-            var setParticleEmissionAction = dungControlFsm.GetAction<SetParticleEmission>("Emit Pause", 1);
+            var setParticleEmissionAction = dungControlFsm.GetFirstAction<SetParticleEmission>("Emit Pause");
             var dungParticleEffect = Object.Instantiate(
                 setParticleEmissionAction.gameObject.GameObject.Value,
                 playerEffects.transform

--- a/HKMP/Animation/Effects/FireballBase.cs
+++ b/HKMP/Animation/Effects/FireballBase.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
@@ -21,10 +21,6 @@ namespace Hkmp.Animation.Effects {
         /// <param name="effectInfo">A boolean array containing effect info.</param>
         /// <param name="fireballParentName">State name of the fireball parent state.</param>
         /// <param name="blastIndex">Index of the blast action.</param>
-        /// <param name="castFireballIndex">Index of the fireball cast action.</param>
-        /// <param name="castAudioIndex">Index of the cast audio action.</param>
-        /// <param name="dungFlukeIndex">Index of the dung fluke action.</param>
-        /// <param name="dungFlukeAudioIndex">Index of the dung fluke audio action.</param>
         /// <param name="baseFireballSize">Float for the size of the base fireball.</param>
         /// <param name="noFireballFlip">Whether to not flip the fireball sprite.</param>
         /// <param name="damage">The damage this spell should do.</param>
@@ -33,10 +29,6 @@ namespace Hkmp.Animation.Effects {
             bool[] effectInfo,
             string fireballParentName,
             int blastIndex,
-            int castFireballIndex,
-            int castAudioIndex,
-            int dungFlukeIndex,
-            int dungFlukeAudioIndex,
             float baseFireballSize,
             bool noFireballFlip,
             int damage
@@ -53,10 +45,10 @@ namespace Hkmp.Animation.Effects {
             // according to the parameters given to this function
             // They are different depending on which level of the Fireball spell we need to create
             var spellControl = HeroController.instance.spellControl;
-            var fireballParent = spellControl.GetAction<SpawnObjectFromGlobalPool>(fireballParentName, 3).gameObject
+            var fireballParent = spellControl.GetFirstAction<SpawnObjectFromGlobalPool>(fireballParentName).gameObject
                 .Value;
             var fireballCast = fireballParent.LocateMyFSM("Fireball Cast");
-            var audioAction = fireballCast.GetAction<AudioPlayerOneShotSingle>("Cast Right", castAudioIndex);
+            var audioAction = fireballCast.GetFirstAction<AudioPlayerOneShotSingle>("Cast Right");
             var audioPlayerObj = audioAction.audioPlayer.Value;
 
             // Get the scale of the player, so we know which way they are facing
@@ -66,7 +58,7 @@ namespace Hkmp.Animation.Effects {
             // First create the blast that appears in front of the knight
             if (blastIndex == 0) {
                 // Take the blast object from the Cast Right state
-                var blastObject = fireballCast.GetAction<CreateObject>("Cast Right", 3);
+                var blastObject = fireballCast.GetFirstAction<CreateObject>("Cast Right");
 
                 // Modify its position based on the values in the FSM and whether the player is facing left or right
                 var position = playerSpells.transform.position
@@ -102,9 +94,9 @@ namespace Hkmp.Animation.Effects {
             if (hasFlukenestCharm) {
                 // The audio clip for a variation containing flukenest is
                 // always the one in the "Fluke R" state of the FSM
-                castClip = (AudioClip) fireballCast.GetAction<AudioPlayerOneShotSingle>("Fluke R", 0).audioClip.Value;
+                castClip = (AudioClip) fireballCast.GetFirstAction<AudioPlayerOneShotSingle>("Fluke R").audioClip.Value;
                 if (hasDefenderCrestCharm) {
-                    var dungFlukeObj = fireballCast.GetAction<SpawnObjectFromGlobalPool>("Dung R", dungFlukeIndex)
+                    var dungFlukeObj = fireballCast.GetFirstAction<SpawnObjectFromGlobalPool>("Dung R")
                         .gameObject.Value;
                     // Instantiate the dungFluke object from the prefab obtained above
                     // Also spawn it a bit above the player position, so it doesn't get stuck
@@ -150,7 +142,7 @@ namespace Hkmp.Animation.Effects {
                     }
 
                     // Start a coroutine, because we need to do some waiting in here
-                    MonoBehaviourUtil.Instance.StartCoroutine(StartDungFluke(dungFluke, dungFlukeAudioIndex));
+                    MonoBehaviourUtil.Instance.StartCoroutine(StartDungFluke(dungFluke));
 
                     Object.Destroy(dungFluke.FindGameObjectInChildren("Damager"));
                 } else {
@@ -162,7 +154,7 @@ namespace Hkmp.Animation.Effects {
                 castClip = (AudioClip) audioAction.audioClip.Value;
 
                 // Get the prefab and instantiate it
-                var fireballObject = fireballCast.GetAction<SpawnObjectFromGlobalPool>("Cast Right", castFireballIndex)
+                var fireballObject = fireballCast.GetFirstAction<SpawnObjectFromGlobalPool>("Cast Right")
                     .gameObject.Value;
                 var fireball = Object.Instantiate(
                     fireballObject,
@@ -212,7 +204,7 @@ namespace Hkmp.Animation.Effects {
         private IEnumerator StartFluke(PlayMakerFSM fireballCast, GameObject playerSpells, bool facingRight,
             int damage) {
             // Obtain the prefab and instantiate it for the fluke only variation
-            var flukeObject = fireballCast.GetAction<FlingObjectsFromGlobalPool>("Flukes", 0).gameObject.Value;
+            var flukeObject = fireballCast.GetFirstAction<FlingObjectsFromGlobalPool>("Flukes").gameObject.Value;
             var fluke = Object.Instantiate(
                 flukeObject,
                 playerSpells.transform.position,
@@ -286,9 +278,8 @@ namespace Hkmp.Animation.Effects {
         /// Start the animation for the dung fluke.
         /// </summary>
         /// <param name="dungFluke">The dung fluke GameObject.</param>
-        /// <param name="dungFlukeAudioIndex">The index of the dung fluke audio action.</param>
         /// <returns>An enumerator for the coroutine.</returns>
-        private IEnumerator StartDungFluke(GameObject dungFluke, int dungFlukeAudioIndex) {
+        private IEnumerator StartDungFluke(GameObject dungFluke) {
             var spriteAnimator = dungFluke.GetComponent<tk2dSpriteAnimator>();
             var dungSpazAudioClip = dungFluke.GetComponent<AudioSource>().clip;
 
@@ -324,7 +315,7 @@ namespace Hkmp.Animation.Effects {
             // Get the control FSM and the audio clip corresponding to the explosion of the dungFluke
             // We need it later
             var dungFlukeControl = dungFluke.LocateMyFSM("Control");
-            var blowClip = (AudioClip) dungFlukeControl.GetAction<AudioPlayerOneShotSingle>("Blow", dungFlukeAudioIndex)
+            var blowClip = (AudioClip) dungFlukeControl.GetFirstAction<AudioPlayerOneShotSingle>("Blow")
                 .audioClip.Value;
             Object.Destroy(dungFlukeControl);
 

--- a/HKMP/Animation/Effects/Focus.cs
+++ b/HKMP/Animation/Effects/Focus.cs
@@ -1,4 +1,4 @@
-﻿using Hkmp.Util;
+using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
 
@@ -15,7 +15,7 @@ namespace Hkmp.Animation.Effects {
             var localSpellControl = HeroController.instance.spellControl;
 
             // Get the AudioPlay action of the Focus Start state
-            var chargeAudioPlay = localSpellControl.GetAction<AudioPlay>("Focus Start", 6);
+            var chargeAudioPlay = localSpellControl.GetFirstAction<AudioPlay>("Focus Start");
 
             // Get the prefab object and instantiate it relative to the player
             var ownerDefaultTarget = chargeAudioPlay.Fsm.GetOwnerDefaultTarget(chargeAudioPlay.gameObject);
@@ -65,7 +65,7 @@ namespace Hkmp.Animation.Effects {
             var linesAnimation = playerObject.FindGameObjectInChildren("Lines Anim");
             if (linesAnimation == null) {
                 // It was not cached, so we create it
-                var meshRendererAction = localSpellControl.GetAction<SetMeshRenderer>("Focus", 7);
+                var meshRendererAction = localSpellControl.GetFirstAction<SetMeshRenderer>("Focus");
                 var linesAnimationObject = meshRendererAction.gameObject.GameObject.Value;
 
                 linesAnimation = Object.Instantiate(
@@ -92,7 +92,7 @@ namespace Hkmp.Animation.Effects {
                     var blockerShieldObject = charmEffects.FindGameObjectInChildren("Blocker Shield");
                     if (blockerShieldObject != null) {
                         var shellFsm = blockerShieldObject.LocateMyFSM("Control");
-                        var playAnimationAction = shellFsm.GetAction<Tk2dPlayAnimation>("Shell Up", 0);
+                        var playAnimationAction = shellFsm.GetFirstAction<Tk2dPlayAnimation>("Shell Up");
 
                         var shellAnimationObject = playAnimationAction.gameObject.GameObject.Value;
                         var shellAnimation = Object.Instantiate(
@@ -115,7 +115,7 @@ namespace Hkmp.Animation.Effects {
                         audioObject.name = "Shell Audio";
                         var audioSource = audioObject.GetComponent<AudioSource>();
 
-                        var audioPlayAction = shellFsm.GetAction<AudioPlayerOneShotSingle>("Shell Up", 2);
+                        var audioPlayAction = shellFsm.GetFirstAction<AudioPlayerOneShotSingle>("Shell Up");
                         audioSource.clip = (AudioClip) audioPlayAction.audioClip.Value;
                         audioSource.Play();
 

--- a/HKMP/Animation/Effects/FocusBurst.cs
+++ b/HKMP/Animation/Effects/FocusBurst.cs
@@ -1,4 +1,4 @@
-﻿using Hkmp.Util;
+using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using Modding;
 using UnityEngine;
@@ -14,7 +14,7 @@ namespace Hkmp.Animation.Effects {
             var localSpellControl = HeroController.instance.spellControl;
 
             // Get the AudioSource from the audio action
-            var audioAction = localSpellControl.GetAction<AudioPlayerOneShotSingle>("Focus Heal", 3);
+            var audioAction = localSpellControl.GetFirstAction<AudioPlayerOneShotSingle>("Focus Heal");
             var audioPlayerObj = audioAction.audioPlayer.Value;
             var audioPlayer = audioPlayerObj.Spawn(playerObject.transform);
             var audioSource = audioPlayer.GetComponent<AudioSource>();
@@ -27,7 +27,7 @@ namespace Hkmp.Animation.Effects {
             Object.Destroy(audioPlayer, healClip.length);
 
             // Get the burst animation object through the Focus Heal state of the FSM
-            var activateObjectAction = localSpellControl.GetAction<ActivateGameObject>("Focus Heal", 10);
+            var activateObjectAction = localSpellControl.GetFirstAction<ActivateGameObject>("Focus Heal");
             var burstAnimationObject = activateObjectAction.gameObject.GameObject.Value;
 
             // Instantiate it relative to the player object
@@ -59,10 +59,10 @@ namespace Hkmp.Animation.Effects {
             GameObject objectVariant;
 
             if (hasDefenderCrest) {
-                var spawnAction = localSpellControl.GetAction<SpawnObjectFromGlobalPool>("Dung Cloud", 0);
+                var spawnAction = localSpellControl.GetFirstAction<SpawnObjectFromGlobalPool>("Dung Cloud");
                 objectVariant = spawnAction.gameObject.Value;
             } else {
-                var spawnAction = localSpellControl.GetAction<SpawnObjectFromGlobalPool>("Spore Cloud", 3);
+                var spawnAction = localSpellControl.GetFirstAction<SpawnObjectFromGlobalPool>("Spore Cloud");
                 objectVariant = spawnAction.gameObject.Value;
             }
 
@@ -118,7 +118,7 @@ namespace Hkmp.Animation.Effects {
                 // Since the event already happened locally, the FSM move to the Cooldown state
                 // thus the only way to check whether we activated the cloud is when the cooldown is "fresh" aka ~0
                 var timeOnCooldown = ReflectionHelper.GetField<Wait, float>(
-                    sporeCooldownFsm.GetAction<Wait>("Cooldown", 0),
+                    sporeCooldownFsm.GetFirstAction<Wait>("Cooldown"),
                     "timer"
                 );
 

--- a/HKMP/Animation/Effects/FocusEnd.cs
+++ b/HKMP/Animation/Effects/FocusEnd.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
@@ -79,7 +79,7 @@ namespace Hkmp.Animation.Effects {
                 var blockerShieldObject = charmEffects.FindGameObjectInChildren("Blocker Shield");
                 var shellFsm = blockerShieldObject.LocateMyFSM("Control");
 
-                var audioPlayAction = shellFsm.GetAction<AudioPlayerOneShotSingle>("Focus End", 1);
+                var audioPlayAction = shellFsm.GetFirstAction<AudioPlayerOneShotSingle>("Focus End");
                 audioSource.clip = (AudioClip) audioPlayAction.audioClip.Value;
                 audioSource.Play();
 

--- a/HKMP/Animation/Effects/GreatSlash.cs
+++ b/HKMP/Animation/Effects/GreatSlash.cs
@@ -1,4 +1,4 @@
-﻿using Hkmp.Util;
+using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
 
@@ -20,7 +20,7 @@ namespace Hkmp.Animation.Effects {
             var audioSource = audioObject.GetComponent<AudioSource>();
 
             // Get the audio clip of the Great Slash
-            var greatSlashClip = (AudioClip) nailArts.GetAction<AudioPlay>("G Slash", 0).oneShotClip.Value;
+            var greatSlashClip = (AudioClip) nailArts.GetFirstAction<AudioPlay>("G Slash").oneShotClip.Value;
             audioSource.PlayOneShot(greatSlashClip);
 
             Object.Destroy(audioObject, greatSlashClip.length);

--- a/HKMP/Animation/Effects/HazardDeath.cs
+++ b/HKMP/Animation/Effects/HazardDeath.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
@@ -35,7 +35,7 @@ namespace Hkmp.Animation.Effects {
                 var spikeDeathFsm = spikeDeath.LocateMyFSM("Knight Death Control");
 
                 // Get the audio play action and change the spawn point of the audio to be the player object
-                var audioPlayAction = spikeDeathFsm.GetAction<AudioPlayerOneShot>("Stab", 4);
+                var audioPlayAction = spikeDeathFsm.GetFirstAction<AudioPlayerOneShot>("Stab");
                 audioPlayAction.spawnPoint.Value = playerObject;
 
                 // Remove the screen shake effect

--- a/HKMP/Animation/Effects/ScreamBase.cs
+++ b/HKMP/Animation/Effects/ScreamBase.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
@@ -28,7 +28,7 @@ namespace Hkmp.Animation.Effects {
             var audioSource = audioObject.GetComponent<AudioSource>();
 
             // Get the correct scream audio clip based on the given parameter
-            var screamClip = (AudioClip) spellControl.GetAction<AudioPlay>(screamClipName, 1).oneShotClip.Value;
+            var screamClip = (AudioClip) spellControl.GetFirstAction<AudioPlay>(screamClipName).oneShotClip.Value;
             // And play it
             audioSource.PlayOneShot(screamClip);
 

--- a/HKMP/Animation/Effects/ShadeSoul.cs
+++ b/HKMP/Animation/Effects/ShadeSoul.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace Hkmp.Animation.Effects {
     /// <summary>
@@ -14,10 +14,6 @@ namespace Hkmp.Animation.Effects {
                 effectInfo,
                 "Fireball 2",
                 1,
-                4,
-                3,
-                0,
-                4,
                 1.8f,
                 false,
                 GameSettings.ShadeSoulDamage

--- a/HKMP/Animation/Effects/SlashBase.cs
+++ b/HKMP/Animation/Effects/SlashBase.cs
@@ -1,4 +1,4 @@
-﻿using Hkmp.Util;
+using Hkmp.Util;
 using HutongGames.PlayMaker.Actions;
 using UnityEngine;
 
@@ -64,7 +64,7 @@ namespace Hkmp.Animation.Effects {
             var nailArts = HeroController.instance.gameObject.LocateMyFSM("Nail Arts");
 
             // Obtain the AudioSource from the AudioPlayerOneShotSingle action in the nail arts FSM
-            var audioAction = nailArts.GetAction<AudioPlayerOneShotSingle>("Play Audio", 0);
+            var audioAction = nailArts.GetFirstAction<AudioPlayerOneShotSingle>("Play Audio");
             var audioPlayerObj = audioAction.audioPlayer.Value;
             var audioPlayer = audioPlayerObj.Spawn(playerObject.transform);
             var audioSource = audioPlayer.GetComponent<AudioSource>();

--- a/HKMP/Animation/Effects/VengefulSpirit.cs
+++ b/HKMP/Animation/Effects/VengefulSpirit.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace Hkmp.Animation.Effects {
     /// <summary>
@@ -14,10 +14,6 @@ namespace Hkmp.Animation.Effects {
                 effectInfo,
                 "Fireball 1",
                 0,
-                7,
-                6,
-                1,
-                3,
                 1.0f,
                 true,
                 GameSettings.VengefulSpiritDamage

--- a/HKMP/Fsm/FsmPatcher.cs
+++ b/HKMP/Fsm/FsmPatcher.cs
@@ -27,7 +27,7 @@ internal class FsmPatcher {
         // Check if it is a FSM for picking up shiny items
         if (self.name.Equals("Inspect Region") && self.Fsm.Name.Equals("inspect")) {
             // Find the action that checks whether the player enters the pickup area
-            var triggerAction = self.GetAction<Trigger2dEvent>("Out Of Range", 1);
+            var triggerAction = self.GetFirstAction<Trigger2dEvent>("Out Of Range");
             if (triggerAction == null) {
                 Logger.Warn("Could not patch inspect FSM, because trigger action does not exist");
                 return;

--- a/HKMP/Util/AudioUtil.cs
+++ b/HKMP/Util/AudioUtil.cs
@@ -1,4 +1,4 @@
-﻿using HutongGames.PlayMaker.Actions;
+using HutongGames.PlayMaker.Actions;
 using UnityEngine;
 
 namespace Hkmp.Util {
@@ -16,7 +16,7 @@ namespace Hkmp.Util {
             var nailArts = HeroController.instance.gameObject.LocateMyFSM("Nail Arts");
 
             // Obtain the AudioSource from the AudioPlayerOneShotSingle action in the nail arts FSM
-            var audioAction = nailArts.GetAction<AudioPlayerOneShotSingle>("Play Audio", 0);
+            var audioAction = nailArts.GetFirstAction<AudioPlayerOneShotSingle>("Play Audio");
             var audioPlayerObj = audioAction.audioPlayer.Value;
 
             return Object.Instantiate(

--- a/HKMP/Util/FsmUtilExt.cs
+++ b/HKMP/Util/FsmUtilExt.cs
@@ -46,14 +46,14 @@ namespace Hkmp.Util {
         }
 
         /// <summary>
-        /// Gets the first action from a given state by Type.
+        /// Get the first FSM action by state name and type.
         /// </summary>
-        /// <typeparam name="T">The type of the action that extends FsmStateAction.</typeparam>
         /// <param name="fsm">The FSM instance.</param>
         /// <param name="stateName">The name of the state.</param>
+        /// <typeparam name="T">The type of the action that extends FsmStateAction.</typeparam>
         /// <returns>The action from the FSM or null if the action could not be found.</returns>
         public static T GetFirstAction<T>(this PlayMakerFSM fsm, string stateName) where T : FsmStateAction {
-            return fsm.GetState(stateName).Actions.OfType<T>().First();
+            return fsm.GetState(stateName)?.Actions.OfType<T>().FirstOrDefault();
         }
 
         /// <summary>

--- a/HKMP/Util/FsmUtilExt.cs
+++ b/HKMP/Util/FsmUtilExt.cs
@@ -46,6 +46,17 @@ namespace Hkmp.Util {
         }
 
         /// <summary>
+        /// Gets the first action from a given state by Type.
+        /// </summary>
+        /// <typeparam name="T">The type of the action that extends FsmStateAction.</typeparam>
+        /// <param name="fsm">The FSM instance.</param>
+        /// <param name="stateName">The name of the state.</param>
+        /// <returns>The action from the FSM or null if the action could not be found.</returns>
+        public static T GetFirstAction<T>(this PlayMakerFSM fsm, string stateName) where T : FsmStateAction {
+            return fsm.GetState(stateName).Actions.OfType<T>().First();
+        }
+
+        /// <summary>
         /// Get a FSM state by its name.
         /// </summary>
         /// <param name="fsm">The FSM instance.</param>


### PR DESCRIPTION
For context - this change keeps compatibility with other mods that modify fsms in slightly - but not substantially - intrusive ways (commonly, this involves adding an InvokeMethod action or equivalent to the start of the state).

In all replaced cases, the action being retrieved was the first one of its type in the state. There were 8 instances that I left; you may want to decide what to do about them yourself.

(Feel free to change the name or implementation of GetFirstAction<T>)