### PR TITLE
Empty scene server crash

### DIFF
--- a/HKMP/Game/Server/ServerManager.cs
+++ b/HKMP/Game/Server/ServerManager.cs
@@ -321,6 +321,16 @@ internal abstract class ServerManager : IServerManager {
         var enterSceneList = new List<ClientPlayerEnterScene>();
         var alreadyPlayersInScene = false;
 
+        // Edge case where the scene of the player is empty (uninitialized) and we don't want to match with other
+        // uninitialized players. Otherwise, it causes issues where other parts of the player data for other players
+        // could be null and result in NREs further down the line
+        if (string.IsNullOrEmpty(playerData.CurrentScene)) {
+            _netServer.GetUpdateManagerForClient(playerData.Id)?.AddPlayerAlreadyInSceneData(
+                enterSceneList,
+                true
+            );
+        }
+
         foreach (var idPlayerDataPair in _playerData) {
             // Skip source player
             if (idPlayerDataPair.Key == playerData.Id) {

--- a/HKMP/Game/Server/ServerManager.cs
+++ b/HKMP/Game/Server/ServerManager.cs
@@ -240,10 +240,12 @@ internal abstract class ServerManager : IServerManager {
             return;
         }
 
-        playerData.CurrentScene = helloServer.SceneName;
+        // Specifically set the position, scale and animation before current scene so that when we check if current
+        // scene exists, we have all other data set
         playerData.Position = helloServer.Position;
         playerData.Scale = helloServer.Scale;
         playerData.AnimationId = helloServer.AnimationClipId;
+        playerData.CurrentScene = helloServer.SceneName;
 
         var clientInfo = new List<(ushort, string)>();
 

--- a/HKMP/Game/Server/ServerPlayerData.cs
+++ b/HKMP/Game/Server/ServerPlayerData.cs
@@ -25,7 +25,7 @@ internal class ServerPlayerData : IServerPlayer {
     public string CurrentScene { get; set; }
 
     /// <inheritdoc />
-    public Vector2 Position { get; set; }
+    public Vector2 Position { get; set; } = Vector2.Zero;
 
     /// <inheritdoc />
     public bool Scale { get; set; }
@@ -34,7 +34,7 @@ internal class ServerPlayerData : IServerPlayer {
     public bool HasMapIcon { get; set; }
 
     /// <inheritdoc />
-    public Vector2 MapPosition { get; set; }
+    public Vector2 MapPosition { get; set; } = Vector2.Zero;
 
     /// <inheritdoc />
     public ushort AnimationId { get; set; }


### PR DESCRIPTION
Fixes #98

Checks whether the scene of a player is null and skips sending data if so. Additionally, the position in server data is initialized by default to a zero vector to prevent it being null in certain checks.