### PR TITLE
Add hooks for HKMP TimeScale changes

### DIFF
--- a/HKMP/Api/Client/IClientManager.cs
+++ b/HKMP/Api/Client/IClientManager.cs
@@ -90,4 +90,14 @@ public interface IClientManager {
     /// Event that is called when another player leaves the local scene.
     /// </summary>
     event Action<IClientPlayer> PlayerLeaveSceneEvent;
+
+    /// <summary>
+    /// Event that is called when HKMP modifies the game's time scale.
+    /// </summary>
+    delegate void SetTimeScale(ref float timeScale);
+
+    /// <summary>
+    /// Event that is called when HKMP modifies the game's time scale.
+    /// </summary>
+    event SetTimeScale OnSetTimeScale;
 }

--- a/HKMP/Api/Client/IClientManager.cs
+++ b/HKMP/Api/Client/IClientManager.cs
@@ -94,7 +94,7 @@ public interface IClientManager {
     /// <summary>
     /// Event that is called when HKMP modifies the game's time scale.
     /// </summary>
-    delegate void SetTimeScale(ref float timeScale);
+    delegate void SetTimeScale(float timeScale);
 
     /// <summary>
     /// Event that is called when HKMP modifies the game's time scale.

--- a/HKMP/Game/Client/ClientManager.cs
+++ b/HKMP/Game/Client/ClientManager.cs
@@ -188,7 +188,7 @@ internal class ClientManager : IClientManager {
 
         _entityManager = new EntityManager(netClient);
 
-        _pauseManager = new PauseManager(netClient, (ref float timeScale) => OnSetTimeScale?.Invoke(ref timeScale));
+        _pauseManager = new PauseManager(netClient, timeScale => OnSetTimeScale?.Invoke(timeScale));
         _pauseManager.RegisterHooks();
 
         new FsmPatcher().RegisterHooks();

--- a/HKMP/Game/Client/PauseManager.cs
+++ b/HKMP/Game/Client/PauseManager.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Reflection;
 using GlobalEnums;
+using Hkmp.Api.Client;
 using Hkmp.Networking.Client;
 using Modding;
 using UnityEngine;
@@ -15,9 +16,15 @@ internal class PauseManager {
     /// The net client instance.
     /// </summary>
     private readonly NetClient _netClient;
+    
+    /// <summary>
+    /// Hook for time scale changes.
+    /// </summary>
+    private readonly IClientManager.SetTimeScale _onSetTimeScale;
 
-    public PauseManager(NetClient netClient) {
+    public PauseManager(NetClient netClient, IClientManager.SetTimeScale onSetTimeScale) {
         _netClient = netClient;
+        _onSetTimeScale = onSetTimeScale;
     }
 
     /// <summary>
@@ -194,7 +201,9 @@ internal class PauseManager {
     /// Sets the time scale similarly to the method GameManager#SetTimeScale.
     /// </summary>
     /// <param name="timeScale">The new time scale.</param>
-    public static void SetTimeScale(float timeScale) {
-        TimeController.GenericTimeScale = timeScale > 0.00999999977648258 ? timeScale : 0.0f;
+    public void SetTimeScale(float timeScale) {
+        timeScale = timeScale > 0.00999999977648258 ? timeScale : 0.0f;
+        _onSetTimeScale(ref timeScale);
+        TimeController.GenericTimeScale = timeScale;
     }
 }

--- a/HKMP/Game/Client/PauseManager.cs
+++ b/HKMP/Game/Client/PauseManager.cs
@@ -203,7 +203,7 @@ internal class PauseManager {
     /// <param name="timeScale">The new time scale.</param>
     public void SetTimeScale(float timeScale) {
         timeScale = timeScale > 0.00999999977648258 ? timeScale : 0.0f;
-        _onSetTimeScale(ref timeScale);
         TimeController.GenericTimeScale = timeScale;
+        _onSetTimeScale(timeScale);
     }
 }


### PR DESCRIPTION
https://github.com/Korzer420/TheHuntIsOn/pull/10 implements an addon to HKMP which facilitates coordinated server-wide pauses and unpauses, which modify the standard Unity timescale.  Since HKMP also modifies the timescale for several reasons, some coordination is required to make this functionality work cleanly without stuttering or overwriting.

This PR funnels all HKMP timescale changes through a public event which can be listened to, allowing consumers to respond to these changes promptly and completely.